### PR TITLE
Use remappings.txt in the Certora prover

### DIFF
--- a/.github/workflows/certora-prover.yml
+++ b/.github/workflows/certora-prover.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           submodules: recursive
 
+      # Install foundry, needed for prover path resolution
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       # Run Certora munge script
       - name: Certora munge
         run: ./certora/scripts/patch.sh

--- a/certora/confs/BaseConfForInheritance.conf
+++ b/certora/confs/BaseConfForInheritance.conf
@@ -23,12 +23,6 @@
         "VaultMock1:_asset=Token0",
         "EulerEarnHarness:_asset=Token0"
     ],
-    "packages": [
-        "ethereum-vault-connector=lib/ethereum-vault-connector/src",
-        "euler-vault-kit=lib/euler-vault-kit/src",
-        "forge-std=lib/forge-std/src",
-        "solmate=lib/euler-vault-kit/lib/permit2/lib/solmate"
-    ],
     "compiler_map": {
         "EulerEarnHarness": "solc-0.8.26",
         "EthereumVaultConnector": "solc-0.8.26",


### PR DESCRIPTION
This PR switches the certora prover to using `remapings.txt`.  The prover can use `remappings.txt` directly, but needs foundry to figure it out.  