### PR TITLE
fix: solar lint

### DIFF
--- a/test/enigma-dark-invariants/Setup.t.sol
+++ b/test/enigma-dark-invariants/Setup.t.sol
@@ -208,13 +208,13 @@ contract Setup is BaseTest {
 
         // STORE MARKETS & VAULTS IN STORAGE
 
-        ///@dev: eulerEarn market
+        /// @dev eulerEarn market
         _pushEVault(address(eulerEarn), address(eTST2), true);
-        ///@dev: eulerEarn market
+        /// @dev eulerEarn market
         _pushEVault(address(eulerEarn), address(eTST3), true);
-        ///@dev: eulerEarn market
+        /// @dev eulerEarn market
         allMarkets[address(eulerEarn)].push(IERC4626(address(eulerEarn2)));
-        ///@dev: eulerEarn2 market
+        /// @dev eulerEarn2 market
         _pushEVault(address(eulerEarn2), address(eTST4), true);
 
         // Set Infinite Cap for Idle Vault


### PR DESCRIPTION
When running `forge build` it fails with the following error and redacts the compiler notes & warnings:

```
❯ forge build
[⠊] Compiling...
[⠒] Compiling 228 files with Solc 0.8.26
[⠆] Solc 0.8.26 finished in 31.10s
Compiler run successful!
Error: Lint failed

Context:
- solar run failed:

error: invalid natspec tag '@dev:', custom tags must use format '@custom:name'
   --> test/enigma-dark-invariants/Setup.t.sol:211:9
    |
211 |         ///@dev: eulerEarn market
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

error: invalid natspec tag '@dev:', custom tags must use format '@custom:name'
   --> test/enigma-dark-invariants/Setup.t.sol:213:9
    |
213 |         ///@dev: eulerEarn market
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

error: invalid natspec tag '@dev:', custom tags must use format '@custom:name'
   --> test/enigma-dark-invariants/Setup.t.sol:215:9
    |
215 |         ///@dev: eulerEarn market
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

error: invalid natspec tag '@dev:', custom tags must use format '@custom:name'
   --> test/enigma-dark-invariants/Setup.t.sol:217:9
    |
217 |         ///@dev: eulerEarn2 market
```

After the fix, we see the the expected build output:

```
❯ forge build
[⠊] Compiling...
[⠊] Compiling 11 files with Solc 0.8.26
[⠒] Solc 0.8.26 finished in 15.51s
Compiler run successful!
note[unaliased-plain-import]: use named imports '{A, B}' or alias 'import ".." as X'
 --> test/enigma-dark-invariants/replays/ReplayTest_5.t.sol:5:8
  |
5 | import "forge-std/Test.sol";
  |        ^^^^^^^^^^^^^^^^^^^^
  |
  = help: https://book.getfoundry.sh/reference/forge/forge-lint#unaliased-plain-import

note[mixed-case-function]: function names should use mixedCase
  --> test/enigma-dark-invariants/Invariants.t.sol:20:14
   |
20 |     function echidna_INV_BASE() public returns (bool) {
   |              ^^^^^^^^^^^^^^^^
   |
   = help: https://book.getfoundry.sh/reference/forge/forge-lint#mixed-case-function

note[mixed-case-function]: function names should use mixedCase
  --> test/enigma-dark-invariants/Invariants.t.sol:37:14
   |
37 |     function echidna_INV_QUEUES() public returns (bool) {
   |              ^^^^^^^^^^^^^^^^^^
   |
   = help: https://book.getfoundry.sh/reference/forge/forge-lint#mixed-case-function

note[unused-import]: unused imports should be removed
 --> src/interfaces/IEulerEarn.sol:4:9
  |
4 | import {IEulerEarnFactory} from "./IEulerEarnFactory.sol";
  |         ^^^^^^^^^^^^^^^^^
  |
  = help: https://book.getfoundry.sh/reference/forge/forge-lint#unused-import

...(continued)
```