### PR TITLE
Rescue strategy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "lib/euler-vault-kit"]
 	path = lib/euler-vault-kit
 	url = https://github.com/euler-xyz/euler-vault-kit
+[submodule "lib/euler-data-lenses"]
+	path = lib/euler-data-lenses
+	url = https://github.com/euler-xyz/euler-data-lenses

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,17 @@
+{
+  "lib/erc4626-tests": {
+    "rev": "232ff9ba8194e406967f52ecc5cb52ed764209e9"
+  },
+  "lib/ethereum-vault-connector": {
+    "rev": "a7d3c29ef7e4964736e47675e0588630d6afbfd7"
+  },
+  "lib/euler-vault-kit": {
+    "rev": "5b98b42048ba11ae82fb62dfec06d1010c8e41e6"
+  },
+  "lib/forge-std": {
+    "rev": "77041d2ce690e692d6e03cc812b57d1ddaa4d505"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "e4f70216d759d8e6a64144a9e1f7bbeed78e7079"
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,6 @@ out = "out"
 libs = ["lib"]
 
 solc = "0.8.26"
-via_ir = true
 optimizer = true
 optimizer_runs = 200
 evm_version = "cancun"

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -90,7 +90,7 @@ contract RescueStrategy is IERC4626 {
             (bool success, bytes memory reason) = earnVault.staticcall(abi.encodeCall(IEulerEarnBase.setFee, (0)));
             require(!success, "expected revert"); // if reentrancy was unlocked, attempt to set it will panic
 
-            if (bytes4(reason) == ReentrancyGuard.ReentrancyGuardReentrantCall.selector)
+            if (reason.length == 4 && bytes4(reason) == ReentrancyGuard.ReentrancyGuardReentrantCall.selector)
                 revert("vault operations are paused - maxWithdraw");
         }
         return 0;

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -105,13 +105,13 @@ contract RescueStrategy {
 	}
 
     // alternative sources of flashloan
-    function rescueEuler(uint256 loanAmount, address flashLoanVault) onlyRescueAccount rescueLock external {
-        bytes memory data = abi.encode(loanAmount, flashLoanVault);
+    function rescueEuler(uint256 loanAmount, uint256 loops, address flashLoanVault) onlyRescueAccount rescueLock external {
+        bytes memory data = abi.encode(loanAmount, loops, flashLoanVault);
 		IFlashLoan(flashLoanVault).flashLoan(loanAmount, data);
 	}
 
     // alternative sources of flashloan
-    function rescueEulerBatch(uint256 loanAmount, address flashLoanVault) onlyRescueAccount rescueLock external {
+    function rescueEulerBatch(uint256 loanAmount, uint256 loops, address flashLoanVault) onlyRescueAccount rescueLock external {
         address evc = EVCUtil(earnVault).EVC();
 
         SafeERC20.forceApprove(_asset, flashLoanVault, loanAmount);
@@ -133,7 +133,7 @@ contract RescueStrategy {
             targetContract: address(this),
             onBehalfOfAccount: address(this),
             value: 0,
-            data: abi.encodeCall(this.onBatchLoan, (loanAmount))
+            data: abi.encodeCall(this.onBatchLoan, (loanAmount, loops))
         });
         batchItems[3] = IEVC.BatchItem({
             targetContract: flashLoanVault,
@@ -152,18 +152,18 @@ contract RescueStrategy {
 	}
 
     // alternative sources of flashloan
-    function rescueMorpho(uint256 loanAmount, address morpho) onlyRescueAccount rescueLock external {
-		IFlashLoan(morpho).flashLoan(address(_asset), loanAmount, "");
+    function rescueMorpho(uint256 loanAmount, uint256 loops, address morpho) onlyRescueAccount rescueLock external {
+        IFlashLoan(morpho).flashLoan(address(_asset), loanAmount, abi.encode(loops));
 	}
 
-	function onBatchLoan(uint256 loanAmount) onlyWhenRescueActive external {
-		_processFlashLoan(loanAmount);
+	function onBatchLoan(uint256 loanAmount, uint256 loops) onlyWhenRescueActive external {
+		_processFlashLoan(loanAmount, loops);
 	}
 
 	function onFlashLoan(bytes memory data) onlyWhenRescueActive external {
-        (uint256 loanAmount, address flashLoanSource) = abi.decode(data, (uint256, address));
+        (uint256 loanAmount, uint256 loops, address flashLoanSource) = abi.decode(data, (uint256, uint256, address));
 
-		_processFlashLoan(loanAmount);
+		_processFlashLoan(loanAmount, loops);
 
         // repay the flashloan
 		SafeERC20.safeTransfer(
@@ -173,8 +173,10 @@ contract RescueStrategy {
 		);
 	}
 
-	function onMorphoFlashLoan(uint256 amount, bytes memory) onlyWhenRescueActive external {
-		_processFlashLoan(amount);
+	function onMorphoFlashLoan(uint256 amount, bytes memory data) onlyWhenRescueActive external {
+        uint256 loops = abi.decode(data, (uint256));
+
+		_processFlashLoan(amount, loops);
 
         SafeERC20.forceApprove(_asset, msg.sender, amount);
 	}
@@ -189,7 +191,7 @@ contract RescueStrategy {
 		revert("vault operations are paused");
 	}
 
-    function _processFlashLoan(uint256 loanAmount) internal {
+    function _processFlashLoan(uint256 loanAmount, uint256 loops) internal {
 		SafeERC20Permit2Lib.forceApproveMaxWithPermit2(
 			_asset,
 			earnVault,
@@ -197,7 +199,9 @@ contract RescueStrategy {
 		);
 
 		// deposit to earn, create shares. Assets will come back here if the strategy is first in supply queue
-		IERC4626(earnVault).deposit(loanAmount, address(this));
+		for (uint256 i = 0; i < loops; i++) {
+            IERC4626(earnVault).deposit(loanAmount, address(this));
+        }
 
         // withdraw as much as possible to the receiver
         uint256 rescuedAmount = IERC4626(earnVault).maxWithdraw(address(this)); 

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -69,8 +69,8 @@ contract RescueStrategy is IEVault {
 
     modifier notEarnMutatingCall() {
         if (!rescueActive && msg.sender == earnVault) {
-            // if reentrancy locked - earn is calling from `withdraw`, which should be prevented
-            // if unlocked - let it through because `maxWithdrawFromStrategy` is called, which is relied upon by the Lens contract
+            // if reentrancy locked - earn is calling from `withdraw` or `deposit`, which should be prevented
+            // if unlocked - let it through because e.g. `maxWithdrawFromStrategy` is called, which is relied upon by the Lens contract
             (bool success, bytes memory reason) = earnVault.staticcall(abi.encodeCall(IEulerEarnBase.setFee, (0)));
             require(!success, "expected revert"); // if reentrancy was unlocked, attempt to set it will panic
 

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.26;
 import {IERC20} from "openzeppelin-contracts/interfaces/IERC20.sol";
 import {IERC20Metadata} from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
 import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+import {IEVault} from "../lib/euler-vault-kit/src/EVault/IEVault.sol";
 import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {IEulerEarn, IEulerEarnBase} from "./interfaces/IEulerEarn.sol";
@@ -41,7 +42,7 @@ interface IFlashLoan {
     ) external;
 }
 
-contract RescueStrategy is IERC4626 {
+contract RescueStrategy is IEVault {
     address public immutable rescueAccount;
     address public immutable earnVault;
     IERC20 internal immutable _asset;
@@ -113,7 +114,7 @@ contract RescueStrategy is IERC4626 {
             return amount;
         }
 
-        revert("not supported");
+        _revertNotSupported();
     }
 
     // ---------------- RESCUE FUNCTIONS --------------------
@@ -225,7 +226,48 @@ contract RescueStrategy is IERC4626 {
         return true;
     }
 
-    // ---------------- ERC4626 compatibility stubs --------------------
+    // ---------------- HELPERS AND INTERNAL --------------------
+
+    // The contract is not supposed to hold any value, but in case of any issues rescue account can exec arbitrary call
+    function call(address target, bytes memory payload) external onlyRescueAccount {
+        (bool success,) = target.call(payload);
+        require(success, "call failed");
+    }
+
+    function _processFlashLoan(uint256 loanAmount, uint256 loops) internal {
+        SafeERC20Permit2Lib.forceApproveMaxWithPermit2(_asset, earnVault, address(0));
+
+        // deposit to earn, create shares. Assets will come back here if the strategy is first in supply queue
+        for (uint256 i = 0; i < loops; i++) {
+            IERC4626(earnVault).deposit(loanAmount, address(this));
+        }
+
+        // withdraw as much as possible to the receiver
+        uint256 rescuedAmount = IERC4626(earnVault).maxWithdraw(address(this));
+        IERC4626(earnVault).withdraw(rescuedAmount, rescueAccount, address(this));
+
+        // send the remaining shares to the receiver
+        IERC4626(earnVault).transfer(rescueAccount, IERC4626(earnVault).balanceOf(address(this)));
+
+        emit Rescued(address(earnVault), rescuedAmount);
+    }
+
+    function _assertRescueMode() internal view {
+        IEulerEarn vault = IEulerEarn(earnVault);
+
+        // Must be the ONLY supply target
+        require(vault.supplyQueueLength() == 1, "rescue: supplyQueue len != 1");
+        require(address(vault.supplyQueue(0)) == address(this), "rescue: supplyQueue[0] != rescue");
+
+        // Must be first in withdraw queue (bank-run guard)
+        require(address(vault.withdrawQueue(0)) == address(this), "rescue: withdrawQueue[0] != rescue");
+    }
+
+    function _revertNotSupported() internal pure {
+        revert("not supported");
+    }
+
+    // ---------------- EVault compatibility stubs --------------------
 
     function symbol() external pure returns (string memory) {
         return "RS";
@@ -288,63 +330,281 @@ contract RescueStrategy is IERC4626 {
     }
 
     function approve(address, uint256) external pure returns (bool) {
-        revert("not supported");
+        _revertNotSupported();
     }
 
     function transfer(address, uint256) external pure returns (bool) {
-        revert("not supported");
+        _revertNotSupported();
     }
 
     function transferFrom(address, address, uint256) external pure returns (bool) {
-        revert("not supported");
+        _revertNotSupported();
     }
 
     function mint(uint256, address) external pure returns (uint256) {
-        revert("not supported");
+        _revertNotSupported();
     }
 
     function redeem(uint256, address, address) external pure returns (uint256) {
-        revert("not supported");
+        _revertNotSupported();
     }
 
     function withdraw(uint256, address, address) external pure returns (uint256) {
-        revert("not supported");
+        _revertNotSupported();
     }
 
-    // ---------------- HELPERS AND INTERNAL --------------------
-
-    // The contract is not supposed to hold any value, but in case of any issues rescue account can exec arbitrary call
-    function call(address target, bytes memory payload) external onlyRescueAccount {
-        (bool success,) = target.call(payload);
-        require(success, "call failed");
+    function transferFromMax(address, address) external pure returns (bool) {
+        _revertNotSupported();
     }
 
-    function _processFlashLoan(uint256 loanAmount, uint256 loops) internal {
-        SafeERC20Permit2Lib.forceApproveMaxWithPermit2(_asset, earnVault, address(0));
-
-        // deposit to earn, create shares. Assets will come back here if the strategy is first in supply queue
-        for (uint256 i = 0; i < loops; i++) {
-            IERC4626(earnVault).deposit(loanAmount, address(this));
-        }
-
-        // withdraw as much as possible to the receiver
-        uint256 rescuedAmount = IERC4626(earnVault).maxWithdraw(address(this));
-        IERC4626(earnVault).withdraw(rescuedAmount, rescueAccount, address(this));
-
-        // send the remaining shares to the receiver
-        IERC4626(earnVault).transfer(rescueAccount, IERC4626(earnVault).balanceOf(address(this)));
-
-        emit Rescued(address(earnVault), rescuedAmount);
+    function accumulatedFees() external pure returns (uint256) {
+        return 0;
     }
 
-    function _assertRescueMode() internal view {
-        IEulerEarn vault = IEulerEarn(earnVault);
-
-        // Must be the ONLY supply target
-        require(vault.supplyQueueLength() == 1, "rescue: supplyQueue len != 1");
-        require(address(vault.supplyQueue(0)) == address(this), "rescue: supplyQueue[0] != rescue");
-
-        // Must be first in withdraw queue (bank-run guard)
-        require(address(vault.withdrawQueue(0)) == address(this), "rescue: withdrawQueue[0] != rescue");
+    function accumulatedFeesAssets() external pure returns (uint256) {
+        return 0;
     }
+
+    function creator() external pure returns (address) {
+        return address(0);
+    }
+
+    function skim(uint256, address) external pure returns (uint256) {
+        _revertNotSupported();
+    }
+
+    function totalBorrows() external pure returns (uint256) {
+        return 0;
+    }
+
+    function totalBorrowsExact() external pure returns (uint256) {
+        return 0;
+    }
+
+    function cash() external pure returns (uint256) {
+        return 0;
+    }
+
+    function debtOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function debtOfExact(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function interestRate() external pure returns (uint256) {
+        return 0;
+    }
+
+    function interestAccumulator() external pure returns (uint256) {
+        return 0;
+    }
+
+    function dToken() external pure returns (address) {
+        return address(0);
+    }
+
+    function borrow(uint256, address) external pure returns (uint256) {
+        _revertNotSupported();
+    }
+
+    function repay(uint256, address) external pure returns (uint256) {
+        _revertNotSupported();
+    }
+
+    function repayWithShares(uint256, address) external pure returns (uint256, uint256) {
+        _revertNotSupported();
+    }
+
+    function pullDebt(uint256, address) external pure {
+        _revertNotSupported();
+    }
+
+    function flashLoan(uint256, bytes calldata) external pure {
+        _revertNotSupported();
+    }
+
+    function touch() external pure {
+        _revertNotSupported();
+    }
+
+    function checkLiquidation(address, address, address) external pure returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    function liquidate(address, address, uint256, uint256) external pure {
+        _revertNotSupported();
+    }
+
+    function accountLiquidity(address, bool) external pure returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    function accountLiquidityFull(address, bool) external pure returns (address[] memory c, uint256[] memory cv, uint256 lv) {}
+
+    function disableController() external pure {
+        _revertNotSupported();
+    }
+
+    function checkAccountStatus(address, address[] calldata) external pure returns (bytes4) {
+        return bytes4(0);
+    }
+
+    function checkVaultStatus() external pure returns (bytes4) {
+        return bytes4(0);
+    }
+
+    function balanceTrackerAddress() external pure returns (address) {
+        return address(0);
+    }
+
+    function balanceForwarderEnabled(address) external pure returns (bool) {
+        return false;
+    }
+
+    function enableBalanceForwarder() external pure {
+        _revertNotSupported();
+    }
+
+    function disableBalanceForwarder() external pure {
+        _revertNotSupported();
+    }
+
+    function governorAdmin() external pure returns (address) {
+        return address(0);
+    }
+
+    function feeReceiver() external pure returns (address) {
+        return address(0);
+    }
+
+    function interestFee() external pure returns (uint16) {
+        return 0;
+    }
+
+    function interestRateModel() external pure returns (address) {
+        return address(0);
+    }
+
+    function protocolConfigAddress() external pure returns (address) {
+        return address(0);
+    }
+
+    function protocolFeeShare() external pure returns (uint256) {
+        return 0;
+    }
+
+    function protocolFeeReceiver() external pure returns (address) {
+        return address(0);
+    }
+
+    function caps() external pure returns (uint16, uint16) {
+        return (0, 0);
+    }
+
+    function LTVBorrow(address) external pure returns (uint16) {
+        return 0;
+    }
+
+    function LTVLiquidation(address) external pure returns (uint16) {
+        return 0;
+    }
+
+    function LTVFull(address collateral) external pure returns (
+            uint16 borrowLTV,
+            uint16 liquidationLTV,
+            uint16 initialLiquidationLTV,
+            uint48 targetTimestamp,
+            uint32 rampDuration
+    ) {}
+
+    function LTVList() external pure returns (address[] memory l) {}
+
+    function maxLiquidationDiscount() external pure returns (uint16) {
+        return 0;
+    }
+
+    function liquidationCoolOffTime() external pure returns (uint16) {
+        return 0;
+    }
+
+    function hookConfig() external pure returns (address hookTarget, uint32 hookedOps) {}
+
+    function configFlags() external pure returns (uint32) {
+        return 0;
+    }
+
+    function EVC() external pure returns (address) {
+        return address(0);
+    }
+
+    function unitOfAccount() external pure returns (address) {
+        return address(0);
+    }
+
+    function oracle() external pure returns (address) {
+        return address(0);
+    }
+
+    function permit2Address() external pure returns (address) {
+        return address(0);
+    }
+
+    function convertFees() external pure {
+        _revertNotSupported();
+    }
+
+    function setGovernorAdmin(address) external pure {
+        _revertNotSupported();
+    }
+
+    function setFeeReceiver(address) external pure {
+        _revertNotSupported();
+    }
+
+    function setLTV(address, uint16, uint16, uint32) external pure {
+        _revertNotSupported();
+    }
+
+    function setMaxLiquidationDiscount(uint16) external pure {
+        _revertNotSupported();
+    }
+
+    function setLiquidationCoolOffTime(uint16) external pure {
+        _revertNotSupported();
+    }
+
+    function setInterestRateModel(address) external pure {
+        _revertNotSupported();
+    }
+
+    function setHookConfig(address, uint32) external pure {
+        _revertNotSupported();
+    }
+
+    function setConfigFlags(uint32) external pure {
+        _revertNotSupported();
+    }
+
+    function setCaps(uint16, uint16) external pure {
+        _revertNotSupported();
+    }
+
+    function setInterestFee(uint16) external pure {
+        _revertNotSupported();
+    }
+
+    function initialize(address) external pure {
+        _revertNotSupported();
+    }
+
+    function MODULE_INITIALIZE() external pure returns (address) { return address(0); }
+    function MODULE_TOKEN() external pure returns (address) { return address(0); }
+    function MODULE_VAULT() external pure returns (address) { return address(0); }
+    function MODULE_BORROWING() external pure returns (address) { return address(0); }
+    function MODULE_LIQUIDATION() external pure returns (address) { return address(0); }
+    function MODULE_RISKMANAGER() external pure returns (address) { return address(0); }
+    function MODULE_BALANCE_FORWARDER() external pure returns (address) { return address(0); }
+    function MODULE_GOVERNANCE() external pure returns (address) { return address(0); }
 }

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -15,21 +15,15 @@ import {IBorrowing, IRiskManager} from "../lib/euler-vault-kit/src/EVault/IEVaul
     - Euler installs a perspective in the earn factory which allows adding custom strategies
     - RescueStrategy contracts are deployed for each earn vault to rescue. 
       Immutable params:
-        o Rescue EOA: is only allowed to call the rescue function directly or through a multisig (tx.origin is checked).
-          It should be a throw-away EOA just for the purpose of rescue, because of tx.origin use.
-        o funds receiver: will receive rescued assets and left over shares (see below)
-        o earn vault: the strategy can only work with the specified vault. If another vault tries to enable it, it will revert on `submitCap`
+        o Rescue account: is allowed to call the rescue functions and receives rescued assets and shares
+        o Earn vault: the strategy can only work with the specified vault. If another vault tries to enable it, it will revert on `acceptCap`
     - Euler registers the strategies in the perspective
     - Curator installs the strategy with unlimited cap (submit/acceptCap)
     - Curator sets the new strategy as the only one in supply queue and moves it to the front of withdraw queue
         o at this stage the regular users can't deposit or withdraw from earn
-    - Rescue EOA calls one of the `rescueX` funcitons (for Euler or Morpho flash loan sources), specifying the asset amount to flashloan
+    - Rescue account calls one of the `rescueX` functions (for Euler, Morpho or Aave flash loan sources), specifying the asset amount to flashloan
         o flash loan is used to create earn vault shares, it just passes through earn vault back to the rescue strategy where it is repaid
-        o the shares are used to withdraw as much as possible from the underlying strategies to the funds receiver
-        o remaining shares are returned to the funds receiver
-        o the rescue function can be called multiple times
-        o the rescue EOA can also withdraw shares at any time, as long as it is tx.origin 
-          (so can also initiate withdrawal if funds receiver is a multisig)
+        o the shares are used to withdraw as much as possible from the underlying strategies to the rescue account
 */
 
 interface IFlashLoan {

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -63,7 +63,20 @@ contract RescueStrategy is IEVault {
     }
 
     modifier onlyWhenRescueActive() {
-        require(rescueActive, "vault operations are paused");
+        require(rescueActive, "unauthorized");
+        _;
+    }
+
+    modifier notEarnMutatingCall() {
+        if (!rescueActive && msg.sender == earnVault) {
+            // if reentrancy locked - earn is calling from `withdraw`, which should be prevented
+            // if unlocked - let it through because `maxWithdrawFromStrategy` is called, which is relied upon by the Lens contract
+            (bool success, bytes memory reason) = earnVault.staticcall(abi.encodeCall(IEulerEarnBase.setFee, (0)));
+            require(!success, "expected revert"); // if reentrancy was unlocked, attempt to set it will panic
+
+            if (reason.length == 4 && bytes4(reason) == ReentrancyGuard.ReentrancyGuardReentrantCall.selector)
+                revert("vault operations are paused");
+        }
         _;
     }
 
@@ -78,22 +91,12 @@ contract RescueStrategy is IEVault {
     // ---------------- RESCUE ENABLING BEHAVIOR --------------------
 
     // will revert user deposits
-    function maxDeposit(address) external view returns (uint256) {
-        require(msg.sender != earnVault || rescueActive, "vault operations are paused - maxDeposit");
-        return msg.sender == earnVault ? type(uint256).max : 0;
+    function maxDeposit(address) external view notEarnMutatingCall returns (uint256) {
+        return msg.sender == earnVault && rescueActive ? type(uint256).max : 0;
     }
 
     // will revert user withdrawals
-    function maxWithdraw(address) external view returns (uint256) {
-        if (!rescueActive && msg.sender == earnVault) {
-            // if reentrancy locked - earn is calling from `withdraw`, which should be prevented
-            // if unlocked - let it through because `maxWithdrawFromStrategy` is called, which is relied upon by the Lens contract
-            (bool success, bytes memory reason) = earnVault.staticcall(abi.encodeCall(IEulerEarnBase.setFee, (0)));
-            require(!success, "expected revert"); // if reentrancy was unlocked, attempt to set it will panic
-
-            if (reason.length == 4 && bytes4(reason) == ReentrancyGuard.ReentrancyGuardReentrantCall.selector)
-                revert("vault operations are paused - maxWithdraw");
-        }
+    function maxWithdraw(address) external view notEarnMutatingCall returns (uint256) {
         return 0;
     }
 

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -163,8 +163,8 @@ contract RescueStrategy {
         IEVC(evc).batch(batchItems);
 	}
 
-    function rescueAave(uint256 loanAmount, uint256 loops, address pool) onlyRescueAccount rescueLock external {
-        bytes memory data = abi.encode(loops);
+    function rescueAave(uint256 loanAmount, uint256 loops, address pool, address feeProvider) onlyRescueAccount rescueLock external {
+        bytes memory data = abi.encode(loops, feeProvider);
 		IFlashLoan(pool).flashLoanSimple(address(this), address(_asset), loanAmount, data, 0);
 	}
 
@@ -208,8 +208,8 @@ contract RescueStrategy {
         address,
         bytes calldata data
     ) onlyWhenRescueActive external returns (bool) {
-        require(_asset.balanceOf(address(this)) >= amount + premium, "insufficient funds to repay flashloan");
-        uint256 loops = abi.decode(data, (uint256));
+        (uint256 loops, address feeProvider) = abi.decode(data, (uint256, address));
+        SafeERC20.safeTransferFrom(_asset, feeProvider, address(this), premium);
 
         _processFlashLoan(amount, loops);
 

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.26;
 import {IERC20} from "openzeppelin-contracts/interfaces/IERC20.sol";
 import {IERC20Metadata} from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
 import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
-import {IEVault} from "../lib/euler-vault-kit/src/EVault/IEVault.sol";
 import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {IEulerEarn, IEulerEarnBase} from "./interfaces/IEulerEarn.sol";
@@ -12,7 +11,7 @@ import {IEulerEarnFactory} from "./interfaces/IEulerEarnFactory.sol";
 import {SafeERC20Permit2Lib} from "./libraries/SafeERC20Permit2Lib.sol";
 import {SafeERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuard} from "openzeppelin-contracts/utils/ReentrancyGuard.sol";
-import {IBorrowing, IRiskManager} from "../lib/euler-vault-kit/src/EVault/IEVault.sol";
+import {IEVault, IBorrowing, IRiskManager} from "../lib/euler-vault-kit/src/EVault/IEVault.sol";
 
 /* 
     Rescue procedure:
@@ -45,6 +44,7 @@ interface IFlashLoan {
 contract RescueStrategy is IEVault {
     address public immutable rescueAccount;
     address public immutable earnVault;
+    address public immutable earnFactory;
     IERC20 internal immutable _asset;
 
     bool internal rescueActive;
@@ -86,6 +86,7 @@ contract RescueStrategy is IEVault {
         rescueAccount = _rescueAccount;
         earnVault = _earnVault;
         _asset = IERC20(IEulerEarn(earnVault).asset());
+        earnFactory = IEulerEarn(_earnVault).creator();
     }
 
     // ---------------- RESCUE ENABLING BEHAVIOR --------------------
@@ -102,7 +103,7 @@ contract RescueStrategy is IEVault {
 
     // this reverts acceptCaps to prevent reusing the whitelisted strategy on other vaults
     function balanceOf(address) external view returns (uint256) {
-        require(!IEulerEarnFactory(IEulerEarn(earnVault).creator()).isVault(msg.sender) || msg.sender == earnVault, "wrong vault");
+        require(!IEulerEarnFactory(earnFactory).isVault(msg.sender) || msg.sender == earnVault, "wrong vault");
         return 0;
     }
 

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -85,7 +85,7 @@ contract RescueStrategy is IERC4626 {
     // will revert user withdrawals
     function maxWithdraw(address) external view returns (uint256) {
         if (!rescueActive && msg.sender == earnVault) {
-            // if reentrancy locked - earn is calling from `withdraw`, which shold be prevented
+            // if reentrancy locked - earn is calling from `withdraw`, which should be prevented
             // if unlocked - let it through because `maxWithdrawFromStrategy` is called, which is relied upon by the Lens contract
             (bool success, bytes memory reason) = earnVault.staticcall(abi.encodeWithSignature("setFee(uint256)", 0));
             require(!success, "expected revert"); // if reentrancy was unlocked, attempt to set it will panic

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -3,9 +3,12 @@ pragma solidity ^0.8.26;
 
 import {IERC20} from "openzeppelin-contracts/interfaces/IERC20.sol";
 import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {IEulerEarn} from "./interfaces/IEulerEarn.sol";
 import {SafeERC20Permit2Lib} from "./libraries/SafeERC20Permit2Lib.sol";
 import {SafeERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+import {IBorrowing, IRiskManager} from "../lib/euler-vault-kit/src/EVault/IEVault.sol";
 
 /* 
     Rescue procedure:
@@ -104,8 +107,53 @@ contract RescueStrategy {
 	}
 
     // alternative sources of flashloan
+    function rescueEulerBatch(uint256 loanAmount, address flashLoanVault) onlyRescueAccount external {
+        address evc = EVCUtil(earnVault).EVC();
+
+        SafeERC20.forceApprove(_asset, flashLoanVault, loanAmount);
+
+        IEVC.BatchItem[] memory batchItems = new IEVC.BatchItem[](5);
+        batchItems[0] = IEVC.BatchItem({
+            targetContract: evc,
+            onBehalfOfAccount: address(0),
+            value: 0,
+            data: abi.encodeCall(IEVC.enableController, (address(this), flashLoanVault))
+        });
+        batchItems[1] = IEVC.BatchItem({
+            targetContract: flashLoanVault,
+            onBehalfOfAccount: address(this),
+            value: 0,
+            data: abi.encodeCall(IBorrowing.borrow, (loanAmount, address(this)))
+        });
+        batchItems[2] = IEVC.BatchItem({
+            targetContract: address(this),
+            onBehalfOfAccount: address(this),
+            value: 0,
+            data: abi.encodeCall(this.onBatchLoan, (loanAmount))
+        });
+        batchItems[3] = IEVC.BatchItem({
+            targetContract: flashLoanVault,
+            onBehalfOfAccount: address(this),
+            value: 0,
+            data: abi.encodeCall(IBorrowing.repay, (loanAmount, address(this)))
+        });
+        batchItems[4] = IEVC.BatchItem({
+            targetContract: flashLoanVault,
+            onBehalfOfAccount: address(this),
+            value: 0,
+            data: abi.encodeCall(IRiskManager.disableController, ())
+        });
+
+        IEVC(evc).batch(batchItems);
+	}
+
+    // alternative sources of flashloan
     function rescueMorpho(uint256 loanAmount, address morpho) onlyRescueAccount external {
 		IFlashLoan(morpho).flashLoan(address(_asset), loanAmount, "");
+	}
+
+	function onBatchLoan(uint256 loanAmount) external {
+		_processFlashLoan(loanAmount);
 	}
 
 	function onFlashLoan(bytes memory data) external {

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -51,6 +51,7 @@ contract RescueStrategy {
 
 	modifier rescueLock() {
         require(!rescueActive, "rescue ongoing");
+        _assertRescueMode();
         rescueActive = true;
 		_;
         rescueActive = false;
@@ -212,5 +213,16 @@ contract RescueStrategy {
         IERC4626(earnVault).transfer(rescueAccount, IERC4626(earnVault).balanceOf(address(this)));
 
         emit Rescued(address(earnVault), rescuedAmount);
+    }
+
+    function _assertRescueMode() internal view {
+        IEulerEarn vault = IEulerEarn(earnVault);
+
+        // Must be the ONLY supply target
+        require(vault.supplyQueueLength() == 1, "rescue: supplyQueue len != 1");
+        require(address(vault.supplyQueue(0)) == address(this), "rescue: supplyQueue[0] != rescue");
+
+        // Must be first in withdraw queue (bank-run guard)
+        require(address(vault.withdrawQueue(0)) == address(this), "rescue: withdrawQueue[0] != rescue");
     }
 }

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.26;
+
+import {IERC20} from "openzeppelin-contracts/interfaces/IERC20.sol";
+import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+import {IEulerEarn} from "./interfaces/IEulerEarn.sol";
+import {SafeERC20Permit2Lib} from "./libraries/SafeERC20Permit2Lib.sol";
+import {SafeERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+
+interface IFlashLoan {
+    function flashLoan(uint256, bytes memory) external;
+    function flashLoan(address, uint256, bytes memory) external;
+}
+
+contract RescueStrategy {
+	address immutable public rescueAccount;
+	address immutable public earnVault;
+	IERC20 immutable internal _asset;
+	address immutable public fundsReceiver;
+
+	modifier onlyRescueAccount() {
+		require(tx.origin == rescueAccount, "vault operations are paused");
+		_;
+	}
+
+    modifier onlyAllowedEarnVault() {
+        require(msg.sender == earnVault, "wrong vault");
+        _;
+    }
+
+	constructor(address _rescueAccount, address _earnVault, address _fundsReceiver) {
+		rescueAccount = _rescueAccount;
+		earnVault = _earnVault;
+        fundsReceiver = _fundsReceiver;
+		_asset = IERC20(IEulerEarn(earnVault).asset());
+		SafeERC20Permit2Lib.forceApproveMaxWithPermit2(
+			_asset,
+			rescueAccount,
+			address(0)
+		);
+	}
+
+    function asset() onlyAllowedEarnVault external view returns(address) {
+        return address(_asset);
+    }
+
+    // will revert user deposits
+	function maxDeposit(address) onlyAllowedEarnVault onlyRescueAccount external view returns (uint256) {
+		return type(uint256).max;
+	}
+
+    // will revert user withdrawals
+	function maxWithdraw(address) onlyAllowedEarnVault onlyRescueAccount external view returns (uint256) {
+		return 0;
+	}
+
+	function previewRedeem(uint256) onlyAllowedEarnVault external view returns (uint256) {
+		return 0;
+	}
+
+	function balanceOf(address) onlyAllowedEarnVault external view returns (uint256) {
+		return 0;
+	}
+
+	function deposit(uint256 amount, address) onlyAllowedEarnVault onlyRescueAccount external returns (uint256) {
+		SafeERC20Permit2Lib.safeTransferFromWithPermit2(
+			_asset,
+			msg.sender,
+			address(this),
+			amount, 
+			IEulerEarn(earnVault).permit2Address()
+		);
+
+        return amount;
+	}
+
+    function rescueEuler(uint256 loanAmount, address flashLoanVault) onlyRescueAccount external {
+        bytes memory data = abi.encode(loanAmount, flashLoanVault);
+		IFlashLoan(flashLoanVault).flashLoan(loanAmount, data);
+	}
+
+    function rescueMorpho(uint256 loanAmount, address morpho) onlyRescueAccount external {
+        bytes memory data = abi.encode(loanAmount, morpho);
+		IFlashLoan(morpho).flashLoan(address(_asset), loanAmount, data);
+	}
+
+	function onFlashLoan(bytes memory data) external {
+        (uint256 loanAmount, address flashLoanSource) = abi.decode(data, (uint256, address));
+
+		_processFlashLoan(loanAmount);
+
+        // repay the flashloan
+		SafeERC20.safeTransfer(
+			_asset,
+			flashLoanSource,
+			loanAmount
+		);
+	}
+
+	function onMorphoFlashLoan(uint256, bytes memory data) external {
+        (uint256 loanAmount, address flashLoanSource) = abi.decode(data, (uint256, address));
+
+		_processFlashLoan(loanAmount);
+
+        SafeERC20.forceApprove(_asset, flashLoanSource, loanAmount);
+	}
+
+	function call(address target, bytes memory payload) onlyRescueAccount external {
+		(bool success,) = target.call(payload);
+		require(success, "call failed");
+	}
+
+	fallback() external {
+		revert("vault operations are paused");
+	}
+
+    function _processFlashLoan(uint256 loanAmount) internal {
+		SafeERC20Permit2Lib.forceApproveMaxWithPermit2(
+			_asset,
+			earnVault,
+			address(0)
+		);
+
+		// deposit to earn. All assets should be allocated to rescue strategy, which returns them to the executor
+		IERC4626(earnVault).deposit(loanAmount, address(this));
+
+        // withdraw as much as possible to the owner
+        IERC4626(earnVault).withdraw(IERC4626(earnVault).maxWithdraw(address(this)), fundsReceiver, address(this));
+
+        // send the remaining shares to the owner
+        IERC4626(earnVault).transfer(fundsReceiver, IERC4626(earnVault).balanceOf(address(this)));
+    }
+}

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.26;
 
 import {IERC20} from "openzeppelin-contracts/interfaces/IERC20.sol";
+import {IERC20Metadata} from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
 import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
 import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
@@ -86,21 +87,20 @@ contract RescueStrategy is IERC4626 {
 
     // will revert user deposits
     function maxDeposit(address) external view returns (uint256) {
-        require(msg.sender != earnVault || rescueActive, "vault operations are paused");
-        return type(uint256).max;
+        require(msg.sender != earnVault || rescueActive, "vault operations are paused - maxDeposit");
+        return msg.sender == earnVault ? type(uint256).max : 0;
     }
 
     // will revert user withdrawals
     function maxWithdraw(address) external view returns (uint256) {
         if (!rescueActive && msg.sender == earnVault) {
             // if reentrancy locked - earn is calling from `withdraw`, which shold be prevented
-            // if unlocked - let it through because `maxWithdrawFromStrategy` is called, and this 
-            // function is relied upon by the Lens contract
-            (bool success, bytes memory reason) = earnVault.staticcall(abi.encodeWithSignature("setFee(uint256)", uint256(0)));
-            require(!success, "expected revert"); // if not reentrancy lock, onlyOwner should revert
+            // if unlocked - let it through because `maxWithdrawFromStrategy` is called, which is relied upon by the Lens contract
+            (bool success, bytes memory reason) = earnVault.staticcall(abi.encodeWithSignature("setFee(uint256)", 0));
+            require(!success, "expected revert"); // if reentrancy was unlocked, attempt to set it will panic
 
             if (bytes4(reason) == ReentrancyGuard.ReentrancyGuardReentrantCall.selector)
-                revert("vault operations are paused");
+                revert("vault operations are paused - maxWithdraw");
         }
         return 0;
     }
@@ -133,8 +133,8 @@ contract RescueStrategy is IERC4626 {
         return "Rescue Strategy";
     }
 
-    function decimals() external pure returns (uint8) {
-        return 18;
+    function decimals() external view returns (uint8) {
+        return IERC20Metadata(address(_asset)).decimals();
     }
 
     function totalAssets() external pure returns (uint256) {
@@ -186,15 +186,15 @@ contract RescueStrategy is IERC4626 {
     }
 
     function approve(address, uint256) external pure returns (bool) {
-        return true;
+        return false;
     }
 
     function transfer(address, uint256) external pure returns (bool) {
-        return true;
+        return false;
     }
 
     function transferFrom(address, address, uint256) external pure returns (bool) {
-        return true;
+        return false;
     }
 
     function withdraw(uint256, address, address) external pure returns (uint256 shares) {

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -6,8 +6,10 @@ import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
 import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {IEulerEarn} from "./interfaces/IEulerEarn.sol";
+import {IEulerEarnFactory} from "./interfaces/IEulerEarnFactory.sol";
 import {SafeERC20Permit2Lib} from "./libraries/SafeERC20Permit2Lib.sol";
 import {SafeERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "openzeppelin-contracts/utils/ReentrancyGuard.sol";
 import {IBorrowing, IRiskManager} from "../lib/euler-vault-kit/src/EVault/IEVault.sol";
 
 /* 
@@ -38,7 +40,7 @@ interface IFlashLoan {
     ) external;
 }
 
-contract RescueStrategy {
+contract RescueStrategy is IERC4626 {
     address public immutable rescueAccount;
     address public immutable earnVault;
     IERC20 internal immutable _asset;
@@ -83,12 +85,23 @@ contract RescueStrategy {
     }
 
     // will revert user deposits
-    function maxDeposit(address) external view onlyAllowedEarnVault onlyWhenRescueActive returns (uint256) {
+    function maxDeposit(address) external view returns (uint256) {
+        require(msg.sender != earnVault || rescueActive, "vault operations are paused");
         return type(uint256).max;
     }
 
     // will revert user withdrawals
-    function maxWithdraw(address) external view onlyAllowedEarnVault onlyWhenRescueActive returns (uint256) {
+    function maxWithdraw(address) external view returns (uint256) {
+        if (!rescueActive && msg.sender == earnVault) {
+            // if reentrancy locked - earn is calling from `withdraw`, which shold be prevented
+            // if unlocked - let it through because `maxWithdrawFromStrategy` is called, and this 
+            // function is relied upon by the Lens contract
+            (bool success, bytes memory reason) = earnVault.staticcall(abi.encodeWithSignature("setFee(uint256)", uint256(0)));
+            require(!success, "expected revert"); // if not reentrancy lock, onlyOwner should revert
+
+            if (bytes4(reason) == ReentrancyGuard.ReentrancyGuardReentrantCall.selector)
+                revert("vault operations are paused");
+        }
         return 0;
     }
 
@@ -97,7 +110,8 @@ contract RescueStrategy {
     }
 
     // this reverts acceptCaps to prevent reusing the whitelisted strategy on other vaults
-    function balanceOf(address) external view onlyAllowedEarnVault returns (uint256) {
+    function balanceOf(address) external view returns (uint256) {
+        require(!IEulerEarnFactory(IEulerEarn(earnVault).creator()).isVault(msg.sender) || msg.sender == earnVault, "wrong vault");
         return 0;
     }
 
@@ -108,6 +122,85 @@ contract RescueStrategy {
 
         return amount;
     }
+
+    // ---------------- ERC4626 compatibility stubs --------------------
+
+    function symbol() external pure returns (string memory) {
+        return "RS";
+    }
+
+    function name() external pure returns (string memory) {
+        return "Rescue Strategy";
+    }
+
+    function decimals() external pure returns (uint8) {
+        return 18;
+    }
+
+    function totalAssets() external pure returns (uint256) {
+        return 0;
+    }
+
+    function totalSupply() external pure returns (uint256) {
+        return 0;
+    }
+
+    function convertToShares(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function convertToAssets(uint256) external pure returns (uint256 assets) {
+        return 0;
+    }
+
+    function previewDeposit(uint256) external pure returns (uint256 shares) {
+        return 0;
+    }
+
+    function maxMint(address) external pure returns (uint256 maxShares) {
+        return 0;
+    }
+
+    function previewMint(uint256) external pure returns (uint256 assets) {
+        return 0;
+    }
+
+    function previewWithdraw(uint256) external pure returns (uint256 shares) {
+        return 0;
+    }
+
+    function maxRedeem(address) external pure returns (uint256 maxShares) {
+        return 0;
+    }
+
+    function mint(uint256, address) external pure returns (uint256 assets) {
+        return 0;
+    }
+
+    function redeem(uint256, address, address) external pure returns (uint256 assets) {
+        return 0;
+    }
+
+    function allowance(address, address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function approve(address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function transfer(address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function transferFrom(address, address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function withdraw(uint256, address, address) external pure returns (uint256 shares) {
+        return 0;
+    }
+
 
     // ---------------- RESCUE FUNCTIONS --------------------
 

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -144,13 +144,13 @@ contract RescueStrategy {
 			address(0)
 		);
 
-		// deposit to earn. All assets should be allocated to rescue strategy, which returns them to the executor
+		// deposit to earn, create shares. Assets will come back here if the strategy is first in supply queue
 		IERC4626(earnVault).deposit(loanAmount, address(this));
 
-        // withdraw as much as possible to the owner
+        // withdraw as much as possible to the receiver
         IERC4626(earnVault).withdraw(IERC4626(earnVault).maxWithdraw(address(this)), fundsReceiver, address(this));
 
-        // send the remaining shares to the owner
+        // send the remaining shares to the receiver
         IERC4626(earnVault).transfer(fundsReceiver, IERC4626(earnVault).balanceOf(address(this)));
     }
 }

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -62,6 +62,7 @@ contract RescueStrategy {
 		);
 	}
 
+    // this reverts submitCaps to prevent reusing the whitelisted strategy on other vaults
     function asset() onlyAllowedEarnVault external view returns(address) {
         return address(_asset);
     }

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -97,11 +97,13 @@ contract RescueStrategy {
         return amount;
 	}
 
+    // alternative sources of flashloan
     function rescueEuler(uint256 loanAmount, address flashLoanVault) onlyRescueAccount external {
         bytes memory data = abi.encode(loanAmount, flashLoanVault);
 		IFlashLoan(flashLoanVault).flashLoan(loanAmount, data);
 	}
 
+    // alternative sources of flashloan
     function rescueMorpho(uint256 loanAmount, address morpho) onlyRescueAccount external {
 		IFlashLoan(morpho).flashLoan(address(_asset), loanAmount, "");
 	}
@@ -125,6 +127,7 @@ contract RescueStrategy {
         SafeERC20.forceApprove(_asset, msg.sender, amount);
 	}
 
+    // The contract is not supposed to hold any value, but in case of any issues rescue account can exec arbitrary call
 	function call(address target, bytes memory payload) onlyRescueAccount external {
 		(bool success,) = target.call(payload);
 		require(success, "call failed");

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -207,7 +207,7 @@ contract RescueStrategy {
         uint256 premium,
         address,
         bytes calldata data
-    ) external returns (bool) {
+    ) onlyWhenRescueActive external returns (bool) {
         require(_asset.balanceOf(address(this)) >= amount + premium, "insufficient funds to repay flashloan");
         uint256 loops = abi.decode(data, (uint256));
 

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -103,8 +103,7 @@ contract RescueStrategy {
 	}
 
     function rescueMorpho(uint256 loanAmount, address morpho) onlyRescueAccount external {
-        bytes memory data = abi.encode(loanAmount, morpho);
-		IFlashLoan(morpho).flashLoan(address(_asset), loanAmount, data);
+		IFlashLoan(morpho).flashLoan(address(_asset), loanAmount, "");
 	}
 
 	function onFlashLoan(bytes memory data) external {
@@ -120,12 +119,10 @@ contract RescueStrategy {
 		);
 	}
 
-	function onMorphoFlashLoan(uint256, bytes memory data) external {
-        (uint256 loanAmount, address flashLoanSource) = abi.decode(data, (uint256, address));
+	function onMorphoFlashLoan(uint256 amount, bytes memory) external {
+		_processFlashLoan(amount);
 
-		_processFlashLoan(loanAmount);
-
-        SafeERC20.forceApprove(_asset, flashLoanSource, loanAmount);
+        SafeERC20.forceApprove(_asset, msg.sender, amount);
 	}
 
 	function call(address target, bytes memory payload) onlyRescueAccount external {

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -66,6 +66,8 @@ contract RescueStrategy {
         _;
     }
 
+    event Rescued(address indexed vault, uint256 assets);
+
 	constructor(address _rescueAccount, address _earnVault) {
 		rescueAccount = _rescueAccount;
 		earnVault = _earnVault;
@@ -203,9 +205,12 @@ contract RescueStrategy {
 		IERC4626(earnVault).deposit(loanAmount, address(this));
 
         // withdraw as much as possible to the receiver
-        IERC4626(earnVault).withdraw(IERC4626(earnVault).maxWithdraw(address(this)), rescueAccount, address(this));
+        uint256 rescuedAmount = IERC4626(earnVault).maxWithdraw(address(this)); 
+        IERC4626(earnVault).withdraw(rescuedAmount, rescueAccount, address(this));
 
         // send the remaining shares to the receiver
         IERC4626(earnVault).transfer(rescueAccount, IERC4626(earnVault).balanceOf(address(this)));
+
+        emit Rescued(address(earnVault), rescuedAmount);
     }
 }

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -7,6 +7,28 @@ import {IEulerEarn} from "./interfaces/IEulerEarn.sol";
 import {SafeERC20Permit2Lib} from "./libraries/SafeERC20Permit2Lib.sol";
 import {SafeERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
 
+/* 
+    Rescue procedure:
+    - Euler installs a perspective in the earn factory which allows adding custom strategies
+    - RescueStrategy contracts are deployed for each earn vault to rescue. 
+      Immutable params:
+        o Rescue EOA: is only allowed to call the rescue function directly or through a multisig (tx.origin is checked).
+          It should be a throw-away EOA just for the purpose of rescue, because of tx.origin use.
+        o funds receiver: will receive rescued assets and left over shares (see below)
+        o earn vault: the strategy can only work with the specified vault. If another vault tries to enable it, it will revert on `submitCap`
+    - Euler registers the strategies in the perspective
+    - Curator installs the strategy with unlimited cap (submit/acceptCap)
+    - Curator sets the new strategy as the only one in supply queue and moves it to the front of withdraw queue
+        o at this stage the regular users can't deposit or withdraw from earn
+    - Rescue EOA calls one of the `rescueX` funcitons (for Euler or Morpho flash loan sources), specifying the asset amount to flashloan
+        o flash loan is used to create earn vault shares, it just passes through earn vault back to the rescue strategy where it is repaid
+        o the shares are used to withdraw as much as possible from the underlying strategies to the funds receiver
+        o remaining shares are returned to the funds receiver
+        o the rescue function can be called multiple times
+        o the rescue EOA can also withdraw shares at any time, as long as it is tx.origin 
+          (so can also initiate withdrawal if funds receiver is a multisig)
+*/
+
 interface IFlashLoan {
     function flashLoan(uint256, bytes memory) external;
     function flashLoan(address, uint256, bytes memory) external;

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -29,7 +29,15 @@ import {IBorrowing, IRiskManager} from "../lib/euler-vault-kit/src/EVault/IEVaul
 interface IFlashLoan {
     function flashLoan(uint256, bytes memory) external;
     function flashLoan(address, uint256, bytes memory) external;
+    function flashLoanSimple(
+        address receiverAddress,
+        address asset,
+        uint256 amount,
+        bytes calldata params,
+        uint16 referralCode
+    ) external;
 }
+
 
 contract RescueStrategy {
 	address immutable public rescueAccount;
@@ -69,6 +77,8 @@ contract RescueStrategy {
 		_asset = IERC20(IEulerEarn(earnVault).asset());
 	}
 
+    // ---------------- VAULT INTERFACE --------------------
+
     function asset() external view returns(address) {
         return address(_asset);
     }
@@ -103,6 +113,8 @@ contract RescueStrategy {
 
         return amount;
 	}
+
+    // ---------------- RESCUE FUNCTIONS --------------------
 
     // alternative sources of flashloan
     function rescueEuler(uint256 loanAmount, uint256 loops, address flashLoanVault) onlyRescueAccount rescueLock external {
@@ -151,10 +163,17 @@ contract RescueStrategy {
         IEVC(evc).batch(batchItems);
 	}
 
+    function rescueAave(uint256 loanAmount, uint256 loops, address pool) onlyRescueAccount rescueLock external {
+        bytes memory data = abi.encode(loops);
+		IFlashLoan(pool).flashLoanSimple(address(this), address(_asset), loanAmount, data, 0);
+	}
+
     // alternative sources of flashloan
     function rescueMorpho(uint256 loanAmount, uint256 loops, address morpho) onlyRescueAccount rescueLock external {
         IFlashLoan(morpho).flashLoan(address(_asset), loanAmount, abi.encode(loops));
 	}
+
+    // ---------------- FLASHLOAN CALLBACKS --------------------
 
 	function onBatchLoan(uint256 loanAmount, uint256 loops) onlyWhenRescueActive external {
 		_processFlashLoan(loanAmount, loops);
@@ -180,6 +199,25 @@ contract RescueStrategy {
 
         SafeERC20.forceApprove(_asset, msg.sender, amount);
 	}
+
+    // aave callback
+    function executeOperation(
+        address,
+        uint256 amount,
+        uint256 premium,
+        address,
+        bytes calldata data
+    ) external returns (bool) {
+        require(_asset.balanceOf(address(this)) >= amount + premium, "insufficient funds to repay flashloan");
+        uint256 loops = abi.decode(data, (uint256));
+
+        _processFlashLoan(amount, loops);
+
+        SafeERC20.forceApprove(_asset, msg.sender, amount + premium);
+        return true;
+    }
+
+    // ---------------- HELPERS AND INTERNAL --------------------
 
     // The contract is not supposed to hold any value, but in case of any issues rescue account can exec arbitrary call
 	function call(address target, bytes memory payload) onlyRescueAccount external {

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -38,11 +38,10 @@ interface IFlashLoan {
     ) external;
 }
 
-
 contract RescueStrategy {
-	address immutable public rescueAccount;
-	address immutable public earnVault;
-	IERC20 immutable internal _asset;
+    address public immutable rescueAccount;
+    address public immutable earnVault;
+    IERC20 internal immutable _asset;
 
     bool internal rescueActive;
 
@@ -51,13 +50,13 @@ contract RescueStrategy {
         _;
     }
 
-	modifier rescueLock() {
+    modifier rescueLock() {
         require(!rescueActive, "rescue ongoing");
         _assertRescueMode();
         rescueActive = true;
-		_;
+        _;
         rescueActive = false;
-	}
+    }
 
     modifier onlyWhenRescueActive() {
         require(rescueActive, "vault operations are paused");
@@ -71,59 +70,63 @@ contract RescueStrategy {
 
     event Rescued(address indexed vault, uint256 assets);
 
-	constructor(address _rescueAccount, address _earnVault) {
-		rescueAccount = _rescueAccount;
-		earnVault = _earnVault;
-		_asset = IERC20(IEulerEarn(earnVault).asset());
-	}
+    constructor(address _rescueAccount, address _earnVault) {
+        rescueAccount = _rescueAccount;
+        earnVault = _earnVault;
+        _asset = IERC20(IEulerEarn(earnVault).asset());
+    }
 
     // ---------------- VAULT INTERFACE --------------------
 
-    function asset() external view returns(address) {
+    function asset() external view returns (address) {
         return address(_asset);
     }
 
     // will revert user deposits
-	function maxDeposit(address) onlyAllowedEarnVault onlyWhenRescueActive external view returns (uint256) {
-		return type(uint256).max;
-	}
+    function maxDeposit(address) external view onlyAllowedEarnVault onlyWhenRescueActive returns (uint256) {
+        return type(uint256).max;
+    }
 
     // will revert user withdrawals
-	function maxWithdraw(address) onlyAllowedEarnVault onlyWhenRescueActive external view returns (uint256) {
-		return 0;
-	}
+    function maxWithdraw(address) external view onlyAllowedEarnVault onlyWhenRescueActive returns (uint256) {
+        return 0;
+    }
 
-	function previewRedeem(uint256) external pure returns (uint256) {
-		return 0;
-	}
+    function previewRedeem(uint256) external pure returns (uint256) {
+        return 0;
+    }
 
     // this reverts acceptCaps to prevent reusing the whitelisted strategy on other vaults
-	function balanceOf(address) onlyAllowedEarnVault external view returns (uint256) {
-		return 0;
-	}
+    function balanceOf(address) external view onlyAllowedEarnVault returns (uint256) {
+        return 0;
+    }
 
-	function deposit(uint256 amount, address) onlyAllowedEarnVault onlyWhenRescueActive external returns (uint256) {
-		SafeERC20Permit2Lib.safeTransferFromWithPermit2(
-			_asset,
-			msg.sender,
-			address(this),
-			amount, 
-			IEulerEarn(earnVault).permit2Address()
-		);
+    function deposit(uint256 amount, address) external onlyAllowedEarnVault onlyWhenRescueActive returns (uint256) {
+        SafeERC20Permit2Lib.safeTransferFromWithPermit2(
+            _asset, msg.sender, address(this), amount, IEulerEarn(earnVault).permit2Address()
+        );
 
         return amount;
-	}
+    }
 
     // ---------------- RESCUE FUNCTIONS --------------------
 
     // alternative sources of flashloan
-    function rescueEuler(uint256 loanAmount, uint256 loops, address flashLoanVault) onlyRescueAccount rescueLock external {
+    function rescueEuler(uint256 loanAmount, uint256 loops, address flashLoanVault)
+        external
+        onlyRescueAccount
+        rescueLock
+    {
         bytes memory data = abi.encode(loanAmount, loops, flashLoanVault);
-		IFlashLoan(flashLoanVault).flashLoan(loanAmount, data);
-	}
+        IFlashLoan(flashLoanVault).flashLoan(loanAmount, data);
+    }
 
     // alternative sources of flashloan
-    function rescueEulerBatch(uint256 loanAmount, uint256 loops, address flashLoanVault) onlyRescueAccount rescueLock external {
+    function rescueEulerBatch(uint256 loanAmount, uint256 loops, address flashLoanVault)
+        external
+        onlyRescueAccount
+        rescueLock
+    {
         address evc = EVCUtil(earnVault).EVC();
 
         SafeERC20.forceApprove(_asset, flashLoanVault, loanAmount);
@@ -161,53 +164,51 @@ contract RescueStrategy {
         });
 
         IEVC(evc).batch(batchItems);
-	}
+    }
 
-    function rescueAave(uint256 loanAmount, uint256 loops, address pool, address feeProvider) onlyRescueAccount rescueLock external {
+    function rescueAave(uint256 loanAmount, uint256 loops, address pool, address feeProvider)
+        external
+        onlyRescueAccount
+        rescueLock
+    {
         bytes memory data = abi.encode(loops, feeProvider);
-		IFlashLoan(pool).flashLoanSimple(address(this), address(_asset), loanAmount, data, 0);
-	}
+        IFlashLoan(pool).flashLoanSimple(address(this), address(_asset), loanAmount, data, 0);
+    }
 
     // alternative sources of flashloan
-    function rescueMorpho(uint256 loanAmount, uint256 loops, address morpho) onlyRescueAccount rescueLock external {
+    function rescueMorpho(uint256 loanAmount, uint256 loops, address morpho) external onlyRescueAccount rescueLock {
         IFlashLoan(morpho).flashLoan(address(_asset), loanAmount, abi.encode(loops));
-	}
+    }
 
     // ---------------- FLASHLOAN CALLBACKS --------------------
 
-	function onBatchLoan(uint256 loanAmount, uint256 loops) onlyWhenRescueActive external {
-		_processFlashLoan(loanAmount, loops);
-	}
+    function onBatchLoan(uint256 loanAmount, uint256 loops) external onlyWhenRescueActive {
+        _processFlashLoan(loanAmount, loops);
+    }
 
-	function onFlashLoan(bytes memory data) onlyWhenRescueActive external {
+    function onFlashLoan(bytes memory data) external onlyWhenRescueActive {
         (uint256 loanAmount, uint256 loops, address flashLoanSource) = abi.decode(data, (uint256, uint256, address));
 
-		_processFlashLoan(loanAmount, loops);
+        _processFlashLoan(loanAmount, loops);
 
         // repay the flashloan
-		SafeERC20.safeTransfer(
-			_asset,
-			flashLoanSource,
-			loanAmount
-		);
-	}
+        SafeERC20.safeTransfer(_asset, flashLoanSource, loanAmount);
+    }
 
-	function onMorphoFlashLoan(uint256 amount, bytes memory data) onlyWhenRescueActive external {
+    function onMorphoFlashLoan(uint256 amount, bytes memory data) external onlyWhenRescueActive {
         uint256 loops = abi.decode(data, (uint256));
 
-		_processFlashLoan(amount, loops);
+        _processFlashLoan(amount, loops);
 
         SafeERC20.forceApprove(_asset, msg.sender, amount);
-	}
+    }
 
     // aave callback
-    function executeOperation(
-        address,
-        uint256 amount,
-        uint256 premium,
-        address,
-        bytes calldata data
-    ) onlyWhenRescueActive external returns (bool) {
+    function executeOperation(address, uint256 amount, uint256 premium, address, bytes calldata data)
+        external
+        onlyWhenRescueActive
+        returns (bool)
+    {
         (uint256 loops, address feeProvider) = abi.decode(data, (uint256, address));
         SafeERC20.safeTransferFrom(_asset, feeProvider, address(this), premium);
 
@@ -220,29 +221,25 @@ contract RescueStrategy {
     // ---------------- HELPERS AND INTERNAL --------------------
 
     // The contract is not supposed to hold any value, but in case of any issues rescue account can exec arbitrary call
-	function call(address target, bytes memory payload) onlyRescueAccount external {
-		(bool success,) = target.call(payload);
-		require(success, "call failed");
-	}
+    function call(address target, bytes memory payload) external onlyRescueAccount {
+        (bool success,) = target.call(payload);
+        require(success, "call failed");
+    }
 
-	fallback() external {
-		revert("vault operations are paused");
-	}
+    fallback() external {
+        revert("vault operations are paused");
+    }
 
     function _processFlashLoan(uint256 loanAmount, uint256 loops) internal {
-		SafeERC20Permit2Lib.forceApproveMaxWithPermit2(
-			_asset,
-			earnVault,
-			address(0)
-		);
+        SafeERC20Permit2Lib.forceApproveMaxWithPermit2(_asset, earnVault, address(0));
 
-		// deposit to earn, create shares. Assets will come back here if the strategy is first in supply queue
-		for (uint256 i = 0; i < loops; i++) {
+        // deposit to earn, create shares. Assets will come back here if the strategy is first in supply queue
+        for (uint256 i = 0; i < loops; i++) {
             IERC4626(earnVault).deposit(loanAmount, address(this));
         }
 
         // withdraw as much as possible to the receiver
-        uint256 rescuedAmount = IERC4626(earnVault).maxWithdraw(address(this)); 
+        uint256 rescuedAmount = IERC4626(earnVault).maxWithdraw(address(this));
         IERC4626(earnVault).withdraw(rescuedAmount, rescueAccount, address(this));
 
         // send the remaining shares to the receiver

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -6,7 +6,7 @@ import {IERC20Metadata} from "openzeppelin-contracts/interfaces/IERC20Metadata.s
 import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
 import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
-import {IEulerEarn} from "./interfaces/IEulerEarn.sol";
+import {IEulerEarn, IEulerEarnBase} from "./interfaces/IEulerEarn.sol";
 import {IEulerEarnFactory} from "./interfaces/IEulerEarnFactory.sol";
 import {SafeERC20Permit2Lib} from "./libraries/SafeERC20Permit2Lib.sol";
 import {SafeERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
@@ -87,7 +87,7 @@ contract RescueStrategy is IERC4626 {
         if (!rescueActive && msg.sender == earnVault) {
             // if reentrancy locked - earn is calling from `withdraw`, which should be prevented
             // if unlocked - let it through because `maxWithdrawFromStrategy` is called, which is relied upon by the Lens contract
-            (bool success, bytes memory reason) = earnVault.staticcall(abi.encodeWithSignature("setFee(uint256)", 0));
+            (bool success, bytes memory reason) = earnVault.staticcall(abi.encodeCall(IEulerEarnBase.setFee, (0)));
             require(!success, "expected revert"); // if reentrancy was unlocked, attempt to set it will panic
 
             if (bytes4(reason) == ReentrancyGuard.ReentrancyGuardReentrantCall.selector)

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -66,11 +66,6 @@ contract RescueStrategy is IERC4626 {
         _;
     }
 
-    modifier onlyAllowedEarnVault() {
-        require(msg.sender == earnVault, "wrong vault");
-        _;
-    }
-
     event Rescued(address indexed vault, uint256 assets);
 
     constructor(address _rescueAccount, address _earnVault) {
@@ -79,11 +74,7 @@ contract RescueStrategy is IERC4626 {
         _asset = IERC20(IEulerEarn(earnVault).asset());
     }
 
-    // ---------------- VAULT INTERFACE --------------------
-
-    function asset() external view returns (address) {
-        return address(_asset);
-    }
+    // ---------------- RESCUE ENABLING BEHAVIOR --------------------
 
     // will revert user deposits
     function maxDeposit(address) external view returns (uint256) {
@@ -105,99 +96,23 @@ contract RescueStrategy is IERC4626 {
         return 0;
     }
 
-    function previewRedeem(uint256) external pure returns (uint256) {
-        return 0;
-    }
-
     // this reverts acceptCaps to prevent reusing the whitelisted strategy on other vaults
     function balanceOf(address) external view returns (uint256) {
         require(!IEulerEarnFactory(IEulerEarn(earnVault).creator()).isVault(msg.sender) || msg.sender == earnVault, "wrong vault");
         return 0;
     }
 
-    function deposit(uint256 amount, address) external onlyAllowedEarnVault onlyWhenRescueActive returns (uint256) {
-        SafeERC20Permit2Lib.safeTransferFromWithPermit2(
-            _asset, msg.sender, address(this), amount, IEulerEarn(earnVault).permit2Address()
-        );
+    function deposit(uint256 amount, address) external  returns (uint256) {
+        if (msg.sender == earnVault) {
+            require(rescueActive, "only during rescue");
 
-        return amount;
-    }
+            SafeERC20Permit2Lib.safeTransferFromWithPermit2(
+                _asset, msg.sender, address(this), amount, IEulerEarn(earnVault).permit2Address()
+            );
 
-    // ---------------- ERC4626 compatibility stubs --------------------
+            return amount;
+        }
 
-    function symbol() external pure returns (string memory) {
-        return "RS";
-    }
-
-    function name() external pure returns (string memory) {
-        return "Rescue Strategy";
-    }
-
-    function decimals() external view returns (uint8) {
-        return IERC20Metadata(address(_asset)).decimals();
-    }
-
-    function allowance(address, address) external pure returns (uint256) {
-        return 0;
-    }
-
-    function totalSupply() external pure returns (uint256) {
-        return 0;
-    }
-
-    function totalAssets() external pure returns (uint256) {
-        return 0;
-    }
-
-    function convertToShares(uint256) external pure returns (uint256) {
-        return 0;
-    }
-
-    function convertToAssets(uint256) external pure returns (uint256) {
-        return 0;
-    }
-
-    function previewDeposit(uint256) external pure returns (uint256) {
-        return 0;
-    }
-
-    function maxMint(address) external pure returns (uint256) {
-        return 0;
-    }
-
-    function previewMint(uint256) external pure returns (uint256) {
-        return 0;
-    }
-
-    function previewWithdraw(uint256) external pure returns (uint256) {
-        return 0;
-    }
-
-    function maxRedeem(address) external pure returns (uint256) {
-        return 0;
-    }
-
-    function approve(address, uint256) external pure returns (bool) {
-        revert("not supported");
-    }
-
-    function transfer(address, uint256) external pure returns (bool) {
-        revert("not supported");
-    }
-
-    function transferFrom(address, address, uint256) external pure returns (bool) {
-        revert("not supported");
-    }
-
-    function mint(uint256, address) external pure returns (uint256) {
-        revert("not supported");
-    }
-
-    function redeem(uint256, address, address) external pure returns (uint256) {
-        revert("not supported");
-    }
-
-    function withdraw(uint256, address, address) external pure returns (uint256) {
         revert("not supported");
     }
 
@@ -310,16 +225,98 @@ contract RescueStrategy is IERC4626 {
         return true;
     }
 
+    // ---------------- ERC4626 compatibility stubs --------------------
+
+    function symbol() external pure returns (string memory) {
+        return "RS";
+    }
+
+    function name() external pure returns (string memory) {
+        return "Rescue Strategy";
+    }
+
+    function decimals() external view returns (uint8) {
+        return IERC20Metadata(address(_asset)).decimals();
+    }
+
+    function allowance(address, address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function totalSupply() external pure returns (uint256) {
+        return 0;
+    }
+
+    function asset() external view returns (address) {
+        return address(_asset);
+    }
+
+    function totalAssets() external pure returns (uint256) {
+        return 0;
+    }
+
+    function convertToShares(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function convertToAssets(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewDeposit(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function maxMint(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewMint(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewWithdraw(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function maxRedeem(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewRedeem(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function approve(address, uint256) external pure returns (bool) {
+        revert("not supported");
+    }
+
+    function transfer(address, uint256) external pure returns (bool) {
+        revert("not supported");
+    }
+
+    function transferFrom(address, address, uint256) external pure returns (bool) {
+        revert("not supported");
+    }
+
+    function mint(uint256, address) external pure returns (uint256) {
+        revert("not supported");
+    }
+
+    function redeem(uint256, address, address) external pure returns (uint256) {
+        revert("not supported");
+    }
+
+    function withdraw(uint256, address, address) external pure returns (uint256) {
+        revert("not supported");
+    }
+
     // ---------------- HELPERS AND INTERNAL --------------------
 
     // The contract is not supposed to hold any value, but in case of any issues rescue account can exec arbitrary call
     function call(address target, bytes memory payload) external onlyRescueAccount {
         (bool success,) = target.call(payload);
         require(success, "call failed");
-    }
-
-    fallback() external {
-        revert("vault operations are paused");
     }
 
     function _processFlashLoan(uint256 loanAmount, uint256 loops) internal {

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -65,8 +65,7 @@ contract RescueStrategy {
 		);
 	}
 
-    // this reverts submitCaps to prevent reusing the whitelisted strategy on other vaults
-    function asset() onlyAllowedEarnVault external view returns(address) {
+    function asset() external view returns(address) {
         return address(_asset);
     }
 
@@ -84,6 +83,7 @@ contract RescueStrategy {
 		return 0;
 	}
 
+    // this reverts acceptCaps to prevent reusing the whitelisted strategy on other vaults
 	function balanceOf(address) onlyAllowedEarnVault external view returns (uint256) {
 		return 0;
 	}

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -137,7 +137,7 @@ contract RescueStrategy is IERC4626 {
         return IERC20Metadata(address(_asset)).decimals();
     }
 
-    function totalAssets() external pure returns (uint256) {
+    function allowance(address, address) external pure returns (uint256) {
         return 0;
     }
 
@@ -145,62 +145,61 @@ contract RescueStrategy is IERC4626 {
         return 0;
     }
 
+    function totalAssets() external pure returns (uint256) {
+        return 0;
+    }
+
     function convertToShares(uint256) external pure returns (uint256) {
         return 0;
     }
 
-    function convertToAssets(uint256) external pure returns (uint256 assets) {
+    function convertToAssets(uint256) external pure returns (uint256) {
         return 0;
     }
 
-    function previewDeposit(uint256) external pure returns (uint256 shares) {
+    function previewDeposit(uint256) external pure returns (uint256) {
         return 0;
     }
 
-    function maxMint(address) external pure returns (uint256 maxShares) {
+    function maxMint(address) external pure returns (uint256) {
         return 0;
     }
 
-    function previewMint(uint256) external pure returns (uint256 assets) {
+    function previewMint(uint256) external pure returns (uint256) {
         return 0;
     }
 
-    function previewWithdraw(uint256) external pure returns (uint256 shares) {
+    function previewWithdraw(uint256) external pure returns (uint256) {
         return 0;
     }
 
-    function maxRedeem(address) external pure returns (uint256 maxShares) {
-        return 0;
-    }
-
-    function mint(uint256, address) external pure returns (uint256 assets) {
-        return 0;
-    }
-
-    function redeem(uint256, address, address) external pure returns (uint256 assets) {
-        return 0;
-    }
-
-    function allowance(address, address) external pure returns (uint256) {
+    function maxRedeem(address) external pure returns (uint256) {
         return 0;
     }
 
     function approve(address, uint256) external pure returns (bool) {
-        return false;
+        revert("not supported");
     }
 
     function transfer(address, uint256) external pure returns (bool) {
-        return false;
+        revert("not supported");
     }
 
     function transferFrom(address, address, uint256) external pure returns (bool) {
-        return false;
+        revert("not supported");
     }
 
-    function withdraw(uint256, address, address) external pure returns (uint256 shares) {
-        return 0;
+    function mint(uint256, address) external pure returns (uint256) {
+        revert("not supported");
     }
 
+    function redeem(uint256, address, address) external pure returns (uint256) {
+        revert("not supported");
+    }
+
+    function withdraw(uint256, address, address) external pure returns (uint256) {
+        revert("not supported");
+    }
 
     // ---------------- RESCUE FUNCTIONS --------------------
 

--- a/src/RescueStrategy.sol
+++ b/src/RescueStrategy.sol
@@ -41,28 +41,35 @@ contract RescueStrategy {
 	address immutable public rescueAccount;
 	address immutable public earnVault;
 	IERC20 immutable internal _asset;
-	address immutable public fundsReceiver;
 
-	modifier onlyRescueAccount() {
-		require(tx.origin == rescueAccount, "vault operations are paused");
+    bool internal rescueActive;
+
+    modifier onlyRescueAccount() {
+        require(msg.sender == rescueAccount, "unauthorized");
+        _;
+    }
+
+	modifier rescueLock() {
+        require(!rescueActive, "rescue ongoing");
+        rescueActive = true;
 		_;
+        rescueActive = false;
 	}
+
+    modifier onlyWhenRescueActive() {
+        require(rescueActive, "vault operations are paused");
+        _;
+    }
 
     modifier onlyAllowedEarnVault() {
         require(msg.sender == earnVault, "wrong vault");
         _;
     }
 
-	constructor(address _rescueAccount, address _earnVault, address _fundsReceiver) {
+	constructor(address _rescueAccount, address _earnVault) {
 		rescueAccount = _rescueAccount;
 		earnVault = _earnVault;
-        fundsReceiver = _fundsReceiver;
 		_asset = IERC20(IEulerEarn(earnVault).asset());
-		SafeERC20Permit2Lib.forceApproveMaxWithPermit2(
-			_asset,
-			rescueAccount,
-			address(0)
-		);
 	}
 
     function asset() external view returns(address) {
@@ -70,16 +77,16 @@ contract RescueStrategy {
     }
 
     // will revert user deposits
-	function maxDeposit(address) onlyAllowedEarnVault onlyRescueAccount external view returns (uint256) {
+	function maxDeposit(address) onlyAllowedEarnVault onlyWhenRescueActive external view returns (uint256) {
 		return type(uint256).max;
 	}
 
     // will revert user withdrawals
-	function maxWithdraw(address) onlyAllowedEarnVault onlyRescueAccount external view returns (uint256) {
+	function maxWithdraw(address) onlyAllowedEarnVault onlyWhenRescueActive external view returns (uint256) {
 		return 0;
 	}
 
-	function previewRedeem(uint256) onlyAllowedEarnVault external view returns (uint256) {
+	function previewRedeem(uint256) external pure returns (uint256) {
 		return 0;
 	}
 
@@ -88,7 +95,7 @@ contract RescueStrategy {
 		return 0;
 	}
 
-	function deposit(uint256 amount, address) onlyAllowedEarnVault onlyRescueAccount external returns (uint256) {
+	function deposit(uint256 amount, address) onlyAllowedEarnVault onlyWhenRescueActive external returns (uint256) {
 		SafeERC20Permit2Lib.safeTransferFromWithPermit2(
 			_asset,
 			msg.sender,
@@ -101,13 +108,13 @@ contract RescueStrategy {
 	}
 
     // alternative sources of flashloan
-    function rescueEuler(uint256 loanAmount, address flashLoanVault) onlyRescueAccount external {
+    function rescueEuler(uint256 loanAmount, address flashLoanVault) onlyRescueAccount rescueLock external {
         bytes memory data = abi.encode(loanAmount, flashLoanVault);
 		IFlashLoan(flashLoanVault).flashLoan(loanAmount, data);
 	}
 
     // alternative sources of flashloan
-    function rescueEulerBatch(uint256 loanAmount, address flashLoanVault) onlyRescueAccount external {
+    function rescueEulerBatch(uint256 loanAmount, address flashLoanVault) onlyRescueAccount rescueLock external {
         address evc = EVCUtil(earnVault).EVC();
 
         SafeERC20.forceApprove(_asset, flashLoanVault, loanAmount);
@@ -148,15 +155,15 @@ contract RescueStrategy {
 	}
 
     // alternative sources of flashloan
-    function rescueMorpho(uint256 loanAmount, address morpho) onlyRescueAccount external {
+    function rescueMorpho(uint256 loanAmount, address morpho) onlyRescueAccount rescueLock external {
 		IFlashLoan(morpho).flashLoan(address(_asset), loanAmount, "");
 	}
 
-	function onBatchLoan(uint256 loanAmount) external {
+	function onBatchLoan(uint256 loanAmount) onlyWhenRescueActive external {
 		_processFlashLoan(loanAmount);
 	}
 
-	function onFlashLoan(bytes memory data) external {
+	function onFlashLoan(bytes memory data) onlyWhenRescueActive external {
         (uint256 loanAmount, address flashLoanSource) = abi.decode(data, (uint256, address));
 
 		_processFlashLoan(loanAmount);
@@ -169,7 +176,7 @@ contract RescueStrategy {
 		);
 	}
 
-	function onMorphoFlashLoan(uint256 amount, bytes memory) external {
+	function onMorphoFlashLoan(uint256 amount, bytes memory) onlyWhenRescueActive external {
 		_processFlashLoan(amount);
 
         SafeERC20.forceApprove(_asset, msg.sender, amount);
@@ -196,9 +203,9 @@ contract RescueStrategy {
 		IERC4626(earnVault).deposit(loanAmount, address(this));
 
         // withdraw as much as possible to the receiver
-        IERC4626(earnVault).withdraw(IERC4626(earnVault).maxWithdraw(address(this)), fundsReceiver, address(this));
+        IERC4626(earnVault).withdraw(IERC4626(earnVault).maxWithdraw(address(this)), rescueAccount, address(this));
 
         // send the remaining shares to the receiver
-        IERC4626(earnVault).transfer(fundsReceiver, IERC4626(earnVault).balanceOf(address(this)));
+        IERC4626(earnVault).transfer(rescueAccount, IERC4626(earnVault).balanceOf(address(this)));
     }
 }

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -285,6 +285,8 @@ contract RescuePOC is Test {
         rescueStrategy.onFlashLoan("");
         vm.expectRevert("vault operations are paused");
         rescueStrategy.onMorphoFlashLoan(1, "");
+        vm.expectRevert("vault operations are paused");
+        rescueStrategy.executeOperation(address(1), 1, 1, address(1), ""); 
     }
 
 	function _installRescueStrategy() internal {

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -158,22 +158,28 @@ contract RescuePOC is Test {
 
         uint256 amount = 5_000_000e6;
         uint256 loops = 1;
+        address feeProvider = makeAddr("feeProvider");
+        address asset = vault.asset();
 
         // only rescue account
         vm.prank(user);
         vm.expectRevert("unauthorized");
-        rescueStrategy.rescueAave(amount, loops, FLASH_LOAN_SOURCE_AAVE);
+        rescueStrategy.rescueAave(amount, loops, FLASH_LOAN_SOURCE_AAVE, feeProvider);
 
-        vm.startPrank(rescueAccount);
-        vm.expectRevert("insufficient funds to repay flashloan");
-        rescueStrategy.rescueAave(amount, loops, FLASH_LOAN_SOURCE_AAVE);
+        vm.prank(rescueAccount);
+        vm.expectRevert("ERC20: transfer amount exceeds allowance");
+        rescueStrategy.rescueAave(amount, loops, FLASH_LOAN_SOURCE_AAVE, feeProvider);
 
-        deal(vault.asset(), address(rescueStrategy), amount * 5 / 10000);
-        rescueStrategy.rescueAave(amount, loops, FLASH_LOAN_SOURCE_AAVE);
+        deal(asset, feeProvider, amount * 5 / 10000);
+        vm.prank(feeProvider);
+        IERC20(asset).approve(address(rescueStrategy), type(uint256).max);
 
-        assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);
+        vm.prank(rescueAccount);
+        rescueStrategy.rescueAave(amount, loops, FLASH_LOAN_SOURCE_AAVE, feeProvider);
 
-        console.log("Rescued", IERC20(vault.asset()).balanceOf(rescueAccount), IEulerEarn(vault.asset()).symbol());
+        assertGt(IERC20(asset).balanceOf(rescueAccount), 0);
+
+        console.log("Rescued", IERC20(asset).balanceOf(rescueAccount), IEulerEarn(vault.asset()).symbol());
         console.log("Received shares", IERC4626(vault).balanceOf(rescueAccount));
     }
 

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -75,6 +75,8 @@ contract RescuePOC is Test {
         rescueStrategy.rescueEulerBatch(amount, FLASH_LOAN_SOURCE_EULER);
 
         vm.startPrank(rescueAccount);
+        vm.expectEmit(true, true, false, false);
+        emit RescueStrategy.Rescued(address(vault), 0);
         rescueStrategy.rescueEulerBatch(amount, FLASH_LOAN_SOURCE_EULER);
 
         assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.26;
+
+import {IERC20} from "openzeppelin-contracts/interfaces/IERC20.sol";
+import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+import {IEulerEarn} from "../src/interfaces/IEulerEarn.sol";
+import {IEulerEarnFactory} from "../src/interfaces/IEulerEarnFactory.sol";
+import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
+import {IAllowanceTransfer} from "../src/interfaces/IAllowanceTransfer.sol";
+import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import {RescueStrategy} from "../src/RescueStrategy.sol";
+import "forge-std/Test.sol";
+
+
+contract RescuePOC is Test {
+    // the earn vault to rescue:
+    address constant EARN_VAULT = 0x3B4802FDb0E5d74aA37d58FD77d63e93d4f9A4AF; // https://app.euler.finance/earn/0x3B4802FDb0E5d74aA37d58FD77d63e93d4f9A4AF?network=ethereum 
+
+    address constant OTHER_EARN_VAULT = 0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB; // https://app.euler.finance/earn/0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB?network=ethereum
+    address constant FLASH_LOAN_SOURCE = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb; // morpho
+    address constant RESCUE_EOA = address(10000);
+    address constant FUNDS_RECEIVER = address(20000);
+
+	IEulerEarn vault;
+
+	string FORK_RPC_URL = vm.envOr("FORK_RPC_URL_MAINNET", string(""));
+	uint256 BLOCK_NUMBER = vm.envOr("FORK_BLOCK_NUMBER", uint256(0));
+
+	uint256 fork;
+
+	address user = makeAddr("user");
+    RescueStrategy rescueStrategy;
+
+ 	function setUp() public {
+		require(bytes(FORK_RPC_URL).length != 0, "No FORK_RPC_URL env found");
+		require(RESCUE_EOA != address(0), "No RESCUE_EOA env found");
+		require(EARN_VAULT != address(0), "No EARN_VAULT env found");
+		require(FLASH_LOAN_SOURCE != address(0), "No FLASH_LOAN_SOURCE env found");
+		require(FUNDS_RECEIVER != address(0), "No FUNDS_RECEIVER env found");
+
+		fork = vm.createSelectFork(FORK_RPC_URL);
+		if (BLOCK_NUMBER > 0) {
+			vm.rollFork(BLOCK_NUMBER);
+		}
+
+		vault = IEulerEarn(EARN_VAULT);
+
+		deal(vault.asset(), user, 100e18);
+		vm.startPrank(user);
+		IERC20(vault.asset()).approve(vault.permit2Address(), type(uint256).max);
+        IAllowanceTransfer(vault.permit2Address()).approve(
+            vault.asset(), address(vault), type(uint160).max, type(uint48).max
+        );
+	}
+
+	function testRescue_pauseForUsers() public {
+		_installRescueStrategy();
+
+		vm.startPrank(user);
+		vm.expectRevert("vault operations are paused");
+		vault.deposit(10, user);
+		vm.expectRevert("vault operations are paused");
+		vault.mint(10, user);
+		vm.expectRevert("vault operations are paused");
+		vault.withdraw(0, user, user);
+		vm.expectRevert("vault operations are paused");
+		vault.redeem(0, user, user);
+	}
+
+    function testRescue_rescueOneGo() public {
+        _installRescueStrategy();
+
+        // create shares equal total supply + extra
+        uint256 amount = vault.previewMint(vault.totalSupply()) * 10001 / 10000;
+
+        vm.startPrank(RESCUE_EOA, RESCUE_EOA);
+        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE);
+
+        assertGt(IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), 0);
+
+        console.log("Rescued", IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), IEulerEarn(vault.asset()).symbol());
+        console.log("Received shares", IERC4626(vault).balanceOf(FUNDS_RECEIVER));
+    }
+
+    function testRescue_rescueMultiple() public {
+        _installRescueStrategy();
+
+        uint256 amount = 1000000000000;
+
+        vm.startPrank(RESCUE_EOA, RESCUE_EOA);
+        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE);
+        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE);
+        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE);
+
+        assertGt(IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), 0);
+
+        console.log("Rescued", IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), IEulerEarn(vault.asset()).symbol());
+        console.log("Received shares", IERC4626(vault).balanceOf(FUNDS_RECEIVER));
+    }
+
+    function testRescue_cantBeReused() public {
+        rescueStrategy = new RescueStrategy(RESCUE_EOA, address(vault), FUNDS_RECEIVER);
+
+		// install perspective in earn factory which will allow custom strategies
+		_installPerspective();
+
+        IEulerEarn otherVault = IEulerEarn(OTHER_EARN_VAULT); // hyperithm euler usdc mainnet
+
+		vm.startPrank(otherVault.curator());
+
+        vm.expectRevert("wrong vault");
+		otherVault.submitCap(IERC4626(address(rescueStrategy)), type(uint184).max);
+    }
+
+    function testRescue_uninstall() public {
+        _installRescueStrategy();
+
+        vm.startPrank(user);
+		vm.expectRevert("vault operations are paused");
+		vault.deposit(10, user);
+
+        vm.startPrank(vault.curator());
+
+        IERC4626 id = IERC4626(address(rescueStrategy));
+        vault.submitCap(id, 0);
+
+		uint256 withdrawQueueLength = vault.withdrawQueueLength();
+		uint256[] memory newIndexes = new uint256[](withdrawQueueLength - 1);
+		newIndexes[0] = withdrawQueueLength - 1;
+	
+		for (uint256 i = 1; i < withdrawQueueLength; i++) {
+			newIndexes[i - 1] = i;
+		}
+
+		vault.updateWithdrawQueue(newIndexes);
+
+        IERC4626[] memory supplyQueue = new IERC4626[](1);
+        supplyQueue[0] = vault.withdrawQueue(0);
+        vault.setSupplyQueue(supplyQueue);
+
+        // the vault is functional
+
+        vm.startPrank(user);
+		vault.deposit(10, user);
+        uint256 balance = vault.balanceOf(user);
+        assertGt(balance, 0);
+		vault.mint(10, user);
+        assertEq(vault.balanceOf(user), balance + 10);
+		vault.redeem(10, user, user);
+        assertEq(vault.balanceOf(user), balance);
+		vault.withdraw(vault.maxWithdraw(user), user, user);
+        assertEq(vault.balanceOf(user), 0);
+    }
+
+	function _installRescueStrategy() internal {
+		// install perspective in earn factory which will allow custom strategies (use mock here)
+		_installPerspective();
+
+		// deploy strategy, set a cap for it and put in in the supply and withdraw queues
+		rescueStrategy = new RescueStrategy(RESCUE_EOA, address(vault), FUNDS_RECEIVER);
+
+		vm.startPrank(vault.curator());
+
+		IERC4626 id = IERC4626(address(rescueStrategy));
+
+		vault.submitCap(id, type(uint184).max);
+
+		skip(vault.timelock());
+
+		vault.acceptCap(id);
+
+		IERC4626[] memory supplyQueue = new IERC4626[](1);
+		supplyQueue[0] = id;
+
+		vault.setSupplyQueue(supplyQueue);
+
+		// move the new strategy to the front of the queue
+		uint256 withdrawQueueLength = vault.withdrawQueueLength();
+		uint256[] memory newIndexes = new uint256[](withdrawQueueLength);
+		newIndexes[0] = withdrawQueueLength - 1;
+	
+		for (uint256 i = 1; i < withdrawQueueLength; i++) {
+			newIndexes[i] = i - 1;
+		}
+
+		vault.updateWithdrawQueue(newIndexes);
+
+        vm.stopPrank();
+	}
+
+	function _installPerspective() internal {
+		vm.startPrank(Ownable(vault.creator()).owner());
+
+		IEulerEarnFactory factory = IEulerEarnFactory(vault.creator());
+		factory.setPerspective(address(new MockPerspective()));
+
+		vm.stopPrank();
+	}
+}
+
+contract MockPerspective {
+    function isVerified(address) external pure returns(bool) {
+        return true;
+    }
+}
+

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -98,6 +98,21 @@ contract RescuePOC is Test {
         console.log("Received shares", IERC4626(vault).balanceOf(FUNDS_RECEIVER));
     }
 
+    function testRescue_rescueEOACanWithdrawAnyTime() public {
+        _installRescueStrategy();
+
+        vm.prank(user);
+		vm.expectRevert("vault operations are paused");
+        vault.withdraw(1e6, user, user);
+
+        deal(address(vault), RESCUE_EOA, 1e6);
+
+        vm.prank(RESCUE_EOA, RESCUE_EOA);
+        vault.withdraw(1e6, RESCUE_EOA, RESCUE_EOA);
+
+        assertEq(IERC20(vault.asset()).balanceOf(RESCUE_EOA), 1e6);
+    }
+
     function testRescue_cantBeReused() public {
         rescueStrategy = new RescueStrategy(RESCUE_EOA, address(vault), FUNDS_RECEIVER);
 

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -136,8 +136,11 @@ contract RescuePOC is Test {
 
 		vm.startPrank(otherVault.curator());
 
-        vm.expectRevert("wrong vault");
 		otherVault.submitCap(IERC4626(address(rescueStrategy)), type(uint184).max);
+        skip(vault.timelock());
+
+        vm.expectRevert("wrong vault");
+        otherVault.acceptCap(IERC4626(address(rescueStrategy)));
     }
 
     function testRescue_uninstall() public {

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -22,6 +22,7 @@ contract RescuePOC is Test {
     address constant FLASH_LOAN_SOURCE_EULER = 0x797DD80692c3b2dAdabCe8e30C07fDE5307D48a9; // Euler Prime - also a strategy in earn
     address constant FLASH_LOAN_SOURCE_AAVE = 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2;
     address constant EARN_LENS = 0xA09144BeAe23D8e7836Aeb0Fe17DD2647241A8bE;
+    address constant EVAULT_LENS = 0xc3c45633E45041BF3BE841f89d2cb51E2F657403;
     uint256 constant BLOCK_NUMBER = 23753054;
 
     IEulerEarn vault;
@@ -313,6 +314,10 @@ contract RescuePOC is Test {
         // lens used in the indexer by setting the `code` in eth_call
         EulerEarnVaultInfoFull memory lensData = indexerLens.getVaultInfoFull(address(vault));
         assertEq(lensData.vault, address(vault));
+
+        // evault lens
+        (success, data) = EVAULT_LENS.call(abi.encodeWithSignature("getVaultInfoFull(address)", address(rescueStrategy)));
+        assertTrue(success && data.length > 0);
     }
 
     function testRescue_maxWithdrawView() external {

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -58,7 +58,7 @@ contract RescuePOC is Test {
 
         vm.prank(rescueAccount);
         vm.expectRevert("rescue: supplyQueue len != 1");
-        rescueStrategy.rescueEulerBatch(1, FLASH_LOAN_SOURCE_EULER);
+        rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER);
 
         IERC4626[] memory supplyQueue = new IERC4626[](1);
 		supplyQueue[0] = vault.supplyQueue(0);
@@ -68,7 +68,7 @@ contract RescuePOC is Test {
 
         vm.prank(rescueAccount);
         vm.expectRevert("rescue: supplyQueue[0] != rescue");
-        rescueStrategy.rescueEulerBatch(1, FLASH_LOAN_SOURCE_EULER);
+        rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER);
 		
         vm.prank(vault.curator());
 		vault.submitCap(id, type(uint184).max);
@@ -84,7 +84,7 @@ contract RescuePOC is Test {
 
         vm.prank(rescueAccount);
         vm.expectRevert("rescue: withdrawQueue[0] != rescue");
-        rescueStrategy.rescueEulerBatch(1, FLASH_LOAN_SOURCE_EULER);
+        rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER);
     }
 
 	function testRescue_pauseForUsers() public {
@@ -105,37 +105,46 @@ contract RescuePOC is Test {
         _installRescueStrategy();
 
         uint256 amount = 100_000e6;
-
+        uint256 loops = 1;
+        uint256 snapshot = vm.snapshotState();
         // only rescue account
         vm.prank(user);
         vm.expectRevert("unauthorized");
-        rescueStrategy.rescueEulerBatch(amount, FLASH_LOAN_SOURCE_EULER);
+        rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_EULER);
 
         vm.startPrank(rescueAccount);
         vm.expectEmit(true, true, false, false);
         emit RescueStrategy.Rescued(address(vault), 0);
-        rescueStrategy.rescueEulerBatch(amount, FLASH_LOAN_SOURCE_EULER);
+        rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_EULER);
 
         assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);
         assertEq(IEVC(vault.EVC()).getControllers(address(rescueStrategy)).length, 0);
+        uint256 rescueOneLoop = IERC20(vault.asset()).balanceOf(rescueAccount);
 
-        console.log("Rescued", IERC20(vault.asset()).balanceOf(rescueAccount), IEulerEarn(vault.asset()).symbol());
+        console.log("Rescued", rescueOneLoop, IEulerEarn(vault.asset()).symbol());
         console.log("Received shares", IERC4626(vault).balanceOf(rescueAccount));
+
+        vm.revertTo(snapshot);
+        loops = 2;
+
+        rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_EULER);
+        assertEq(IERC20(vault.asset()).balanceOf(rescueAccount), rescueOneLoop * 2);
     }
 
     function testRescue_rescueMorpho() public {
         _installRescueStrategy();
 
         // create shares equal total supply + extra
-        uint256 amount = vault.previewMint(vault.totalSupply()) * 10001 / 10000;
+        uint256 amount = vault.previewMint(vault.totalSupply()) * 10001 / 10000 / 2;
+        uint256 loops = 2;
 
         // only rescue account
         vm.prank(user);
         vm.expectRevert("unauthorized");
-        rescueStrategy.rescueEulerBatch(amount, FLASH_LOAN_SOURCE_MORPHO);
+        rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_MORPHO);
 
         vm.startPrank(rescueAccount);
-        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
+        rescueStrategy.rescueMorpho(amount, loops, FLASH_LOAN_SOURCE_MORPHO);
 
         assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);
 
@@ -147,11 +156,12 @@ contract RescuePOC is Test {
         _installRescueStrategy();
 
         uint256 amount = 1000000000000;
+        uint256 loops = 1;
 
         vm.startPrank(rescueAccount);
-        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
-        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
-        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
+        rescueStrategy.rescueMorpho(amount, loops, FLASH_LOAN_SOURCE_MORPHO);
+        rescueStrategy.rescueMorpho(amount, loops, FLASH_LOAN_SOURCE_MORPHO);
+        rescueStrategy.rescueMorpho(amount, loops, FLASH_LOAN_SOURCE_MORPHO);
 
         assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);
 
@@ -245,7 +255,7 @@ contract RescuePOC is Test {
         _installRescueStrategy();
 
         vm.expectRevert("vault operations are paused");
-        rescueStrategy.onBatchLoan(1);
+        rescueStrategy.onBatchLoan(1, 1);
         vm.expectRevert("vault operations are paused");
         rescueStrategy.onFlashLoan("");
         vm.expectRevert("vault operations are paused");

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -112,8 +112,16 @@ contract RescuePOC is Test {
         assertEq(vault.maxWithdrawFromStrategy(IERC4626(address(rescueStrategy))), 0);
     }
 
+    mapping (address => uint256) strategyCaps;
     function testRescue_rescueEulerBatch() public {
         _installRescueStrategy();
+
+        uint256 withdrawQueueLength = vault.withdrawQueueLength();
+
+        for (uint256 i = 0; i < withdrawQueueLength; i++) {
+            address strategy = address(vault.withdrawQueue(i));
+            strategyCaps[strategy] = vault.config(vault.withdrawQueue(i)).cap;
+        }
 
         uint256 amount = 100_000e6;
         uint256 loops = 1;
@@ -140,6 +148,15 @@ contract RescuePOC is Test {
 
         rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_EULER);
         assertEq(IERC20(vault.asset()).balanceOf(rescueAccount), rescueOneLoop * 2);
+
+        // caps are unchanged on other strategies
+
+        for (uint256 i = 0; i < withdrawQueueLength; i++) {
+            address strategy = address(vault.withdrawQueue(i));
+            if (strategy != address(rescueStrategy)) {
+                assertEq(strategyCaps[strategy], vault.config(vault.withdrawQueue(i)).cap);
+            }
+        }
     }
 
     function testRescue_rescueMorpho() public {
@@ -242,9 +259,24 @@ contract RescuePOC is Test {
     function testRescue_uninstall() public {
         _installRescueStrategy();
 
+        // exchange rate should remain constant (besides rounding)
+        uint256 sharePriceBefore = vault.convertToAssets(1e18);
+        uint256 lostAssetsBefore = vault.lostAssets();
+
         vm.startPrank(user);
         vm.expectRevert("vault operations are paused");
         vault.deposit(10, user);
+
+        // rescue
+        uint256 amount = vault.previewMint(vault.totalSupply()) * 10001 / 10000 ;
+        uint256 loops = 1;
+
+        vm.startPrank(rescueAccount);
+        rescueStrategy.rescueMorpho(amount, loops, FLASH_LOAN_SOURCE_MORPHO);
+
+        assertApproxEqAbs(sharePriceBefore, vault.convertToAssets(1e18), 1e5);
+        // all the deposited amount is counted as lost
+        assertEq(vault.lostAssets(), lostAssetsBefore + amount);
 
         vm.startPrank(vault.curator());
 
@@ -267,6 +299,8 @@ contract RescuePOC is Test {
 
         // the vault is functional
 
+        assertApproxEqAbs(sharePriceBefore, vault.convertToAssets(1e18), 1e5);
+
         vm.startPrank(user);
         vault.deposit(10, user);
         uint256 balance = vault.balanceOf(user);
@@ -277,6 +311,8 @@ contract RescuePOC is Test {
         assertEq(vault.balanceOf(user), balance);
         vault.withdraw(vault.maxWithdraw(user), user, user);
         assertEq(vault.balanceOf(user), 0);
+
+        assertApproxEqAbs(sharePriceBefore, vault.convertToAssets(1e18), 1e6);
     }
 
     function testRescue_onlyRescueAccountCallFunc() external {

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -99,6 +99,8 @@ contract RescuePOC is Test {
         vault.withdraw(0, user, user);
         vm.expectRevert("vault operations are paused");
         vault.redeem(0, user, user);
+
+        assertEq(vault.maxWithdrawFromStrategy(IERC4626(address(rescueStrategy))), 0);
     }
 
     function testRescue_rescueEulerBatch() public {

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -12,10 +12,9 @@ import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.
 import {RescueStrategy} from "../src/RescueStrategy.sol";
 import "forge-std/Test.sol";
 
-
 contract RescuePOC is Test {
     // the earn vault to rescue:
-    address constant EARN_VAULT = 0x3B4802FDb0E5d74aA37d58FD77d63e93d4f9A4AF; // https://app.euler.finance/earn/0x3B4802FDb0E5d74aA37d58FD77d63e93d4f9A4AF?network=ethereum 
+    address constant EARN_VAULT = 0x3B4802FDb0E5d74aA37d58FD77d63e93d4f9A4AF; // https://app.euler.finance/earn/0x3B4802FDb0E5d74aA37d58FD77d63e93d4f9A4AF?network=ethereum
 
     address constant OTHER_EARN_VAULT = 0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB; // https://app.euler.finance/earn/0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB?network=ethereum
     address constant FLASH_LOAN_SOURCE_MORPHO = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
@@ -23,38 +22,38 @@ contract RescuePOC is Test {
     address constant FLASH_LOAN_SOURCE_AAVE = 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2;
     uint256 constant BLOCK_NUMBER = 23753054;
 
-	IEulerEarn vault;
+    IEulerEarn vault;
 
-	string FORK_RPC_URL = vm.envOr("FORK_RPC_URL_MAINNET", string(""));
+    string FORK_RPC_URL = vm.envOr("FORK_RPC_URL_MAINNET", string(""));
 
-	uint256 fork;
+    uint256 fork;
 
     address rescueAccount = makeAddr("rescueAccount");
-	address user = makeAddr("user");
+    address user = makeAddr("user");
     RescueStrategy rescueStrategy;
 
- 	function setUp() public {
-		require(bytes(FORK_RPC_URL).length != 0, "No FORK_RPC_URL env found");
+    function setUp() public {
+        require(bytes(FORK_RPC_URL).length != 0, "No FORK_RPC_URL env found");
 
-		fork = vm.createSelectFork(FORK_RPC_URL);
-		if (BLOCK_NUMBER > 0) {
-			vm.rollFork(BLOCK_NUMBER);
-		}
+        fork = vm.createSelectFork(FORK_RPC_URL);
+        if (BLOCK_NUMBER > 0) {
+            vm.rollFork(BLOCK_NUMBER);
+        }
 
-		vault = IEulerEarn(EARN_VAULT);
+        vault = IEulerEarn(EARN_VAULT);
 
-		deal(vault.asset(), user, 100e18);
-		vm.startPrank(user);
-		IERC20(vault.asset()).approve(vault.permit2Address(), type(uint256).max);
+        deal(vault.asset(), user, 100e18);
+        vm.startPrank(user);
+        IERC20(vault.asset()).approve(vault.permit2Address(), type(uint256).max);
         IAllowanceTransfer(vault.permit2Address()).approve(
             vault.asset(), address(vault), type(uint160).max, type(uint48).max
         );
-	}
+    }
 
     function testRescue_assertRescueMode() public {
-		_installPerspective();
+        _installPerspective();
 
-		rescueStrategy = new RescueStrategy(rescueAccount, address(vault));
+        rescueStrategy = new RescueStrategy(rescueAccount, address(vault));
         IERC4626 id = IERC4626(address(rescueStrategy));
 
         vm.prank(rescueAccount);
@@ -62,45 +61,45 @@ contract RescuePOC is Test {
         rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER);
 
         IERC4626[] memory supplyQueue = new IERC4626[](1);
-		supplyQueue[0] = vault.supplyQueue(0);
+        supplyQueue[0] = vault.supplyQueue(0);
 
-		vm.prank(vault.curator());
+        vm.prank(vault.curator());
         vault.setSupplyQueue(supplyQueue);
 
         vm.prank(rescueAccount);
         vm.expectRevert("rescue: supplyQueue[0] != rescue");
         rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER);
-		
-        vm.prank(vault.curator());
-		vault.submitCap(id, type(uint184).max);
-
-		skip(vault.timelock());
 
         vm.prank(vault.curator());
-		vault.acceptCap(id);
-		supplyQueue[0] = id;
+        vault.submitCap(id, type(uint184).max);
+
+        skip(vault.timelock());
 
         vm.prank(vault.curator());
-		vault.setSupplyQueue(supplyQueue);
+        vault.acceptCap(id);
+        supplyQueue[0] = id;
+
+        vm.prank(vault.curator());
+        vault.setSupplyQueue(supplyQueue);
 
         vm.prank(rescueAccount);
         vm.expectRevert("rescue: withdrawQueue[0] != rescue");
         rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER);
     }
 
-	function testRescue_pauseForUsers() public {
-		_installRescueStrategy();
+    function testRescue_pauseForUsers() public {
+        _installRescueStrategy();
 
-		vm.startPrank(user);
-		vm.expectRevert("vault operations are paused");
-		vault.deposit(10, user);
-		vm.expectRevert("vault operations are paused");
-		vault.mint(10, user);
-		vm.expectRevert("vault operations are paused");
-		vault.withdraw(0, user, user);
-		vm.expectRevert("vault operations are paused");
-		vault.redeem(0, user, user);
-	}
+        vm.startPrank(user);
+        vm.expectRevert("vault operations are paused");
+        vault.deposit(10, user);
+        vm.expectRevert("vault operations are paused");
+        vault.mint(10, user);
+        vm.expectRevert("vault operations are paused");
+        vault.withdraw(0, user, user);
+        vm.expectRevert("vault operations are paused");
+        vault.redeem(0, user, user);
+    }
 
     function testRescue_rescueEulerBatch() public {
         _installRescueStrategy();
@@ -204,7 +203,7 @@ contract RescuePOC is Test {
         _installRescueStrategy();
 
         vm.prank(user);
-		vm.expectRevert("vault operations are paused");
+        vm.expectRevert("vault operations are paused");
         vault.withdraw(1e6, user, user);
 
         deal(address(vault), rescueAccount, 1e6);
@@ -217,14 +216,14 @@ contract RescuePOC is Test {
     function testRescue_cantBeReused() public {
         rescueStrategy = new RescueStrategy(rescueAccount, address(vault));
 
-		// install perspective in earn factory which will allow custom strategies
-		_installPerspective();
+        // install perspective in earn factory which will allow custom strategies
+        _installPerspective();
 
         IEulerEarn otherVault = IEulerEarn(OTHER_EARN_VAULT); // hyperithm euler usdc mainnet
 
-		vm.startPrank(otherVault.curator());
+        vm.startPrank(otherVault.curator());
 
-		otherVault.submitCap(IERC4626(address(rescueStrategy)), type(uint184).max);
+        otherVault.submitCap(IERC4626(address(rescueStrategy)), type(uint184).max);
         skip(vault.timelock());
 
         vm.expectRevert("wrong vault");
@@ -235,23 +234,23 @@ contract RescuePOC is Test {
         _installRescueStrategy();
 
         vm.startPrank(user);
-		vm.expectRevert("vault operations are paused");
-		vault.deposit(10, user);
+        vm.expectRevert("vault operations are paused");
+        vault.deposit(10, user);
 
         vm.startPrank(vault.curator());
 
         IERC4626 id = IERC4626(address(rescueStrategy));
         vault.submitCap(id, 0);
 
-		uint256 withdrawQueueLength = vault.withdrawQueueLength();
-		uint256[] memory newIndexes = new uint256[](withdrawQueueLength - 1);
-		newIndexes[0] = withdrawQueueLength - 1;
-	
-		for (uint256 i = 1; i < withdrawQueueLength; i++) {
-			newIndexes[i - 1] = i;
-		}
+        uint256 withdrawQueueLength = vault.withdrawQueueLength();
+        uint256[] memory newIndexes = new uint256[](withdrawQueueLength - 1);
+        newIndexes[0] = withdrawQueueLength - 1;
 
-		vault.updateWithdrawQueue(newIndexes);
+        for (uint256 i = 1; i < withdrawQueueLength; i++) {
+            newIndexes[i - 1] = i;
+        }
+
+        vault.updateWithdrawQueue(newIndexes);
 
         IERC4626[] memory supplyQueue = new IERC4626[](1);
         supplyQueue[0] = vault.withdrawQueue(0);
@@ -260,14 +259,14 @@ contract RescuePOC is Test {
         // the vault is functional
 
         vm.startPrank(user);
-		vault.deposit(10, user);
+        vault.deposit(10, user);
         uint256 balance = vault.balanceOf(user);
         assertGt(balance, 0);
-		vault.mint(10, user);
+        vault.mint(10, user);
         assertEq(vault.balanceOf(user), balance + 10);
-		vault.redeem(10, user, user);
+        vault.redeem(10, user, user);
         assertEq(vault.balanceOf(user), balance);
-		vault.withdraw(vault.maxWithdraw(user), user, user);
+        vault.withdraw(vault.maxWithdraw(user), user, user);
         assertEq(vault.balanceOf(user), 0);
     }
 
@@ -292,58 +291,57 @@ contract RescuePOC is Test {
         vm.expectRevert("vault operations are paused");
         rescueStrategy.onMorphoFlashLoan(1, "");
         vm.expectRevert("vault operations are paused");
-        rescueStrategy.executeOperation(address(1), 1, 1, address(1), ""); 
+        rescueStrategy.executeOperation(address(1), 1, 1, address(1), "");
     }
 
-	function _installRescueStrategy() internal {
-		// install perspective in earn factory which will allow custom strategies (use mock here)
-		_installPerspective();
+    function _installRescueStrategy() internal {
+        // install perspective in earn factory which will allow custom strategies (use mock here)
+        _installPerspective();
 
-		// deploy strategy, set a cap for it and put in in the supply and withdraw queues
-		rescueStrategy = new RescueStrategy(rescueAccount, address(vault));
+        // deploy strategy, set a cap for it and put in in the supply and withdraw queues
+        rescueStrategy = new RescueStrategy(rescueAccount, address(vault));
 
-		vm.startPrank(vault.curator());
+        vm.startPrank(vault.curator());
 
-		IERC4626 id = IERC4626(address(rescueStrategy));
+        IERC4626 id = IERC4626(address(rescueStrategy));
 
-		vault.submitCap(id, type(uint184).max);
+        vault.submitCap(id, type(uint184).max);
 
-		skip(vault.timelock());
+        skip(vault.timelock());
 
-		vault.acceptCap(id);
+        vault.acceptCap(id);
 
-		IERC4626[] memory supplyQueue = new IERC4626[](1);
-		supplyQueue[0] = id;
+        IERC4626[] memory supplyQueue = new IERC4626[](1);
+        supplyQueue[0] = id;
 
-		vault.setSupplyQueue(supplyQueue);
+        vault.setSupplyQueue(supplyQueue);
 
-		// move the new strategy to the front of the queue
-		uint256 withdrawQueueLength = vault.withdrawQueueLength();
-		uint256[] memory newIndexes = new uint256[](withdrawQueueLength);
-		newIndexes[0] = withdrawQueueLength - 1;
-	
-		for (uint256 i = 1; i < withdrawQueueLength; i++) {
-			newIndexes[i] = i - 1;
-		}
+        // move the new strategy to the front of the queue
+        uint256 withdrawQueueLength = vault.withdrawQueueLength();
+        uint256[] memory newIndexes = new uint256[](withdrawQueueLength);
+        newIndexes[0] = withdrawQueueLength - 1;
 
-		vault.updateWithdrawQueue(newIndexes);
+        for (uint256 i = 1; i < withdrawQueueLength; i++) {
+            newIndexes[i] = i - 1;
+        }
+
+        vault.updateWithdrawQueue(newIndexes);
 
         vm.stopPrank();
-	}
+    }
 
-	function _installPerspective() internal {
-		vm.startPrank(Ownable(vault.creator()).owner());
+    function _installPerspective() internal {
+        vm.startPrank(Ownable(vault.creator()).owner());
 
-		IEulerEarnFactory factory = IEulerEarnFactory(vault.creator());
-		factory.setPerspective(address(new MockPerspective()));
+        IEulerEarnFactory factory = IEulerEarnFactory(vault.creator());
+        factory.setPerspective(address(new MockPerspective()));
 
-		vm.stopPrank();
-	}
+        vm.stopPrank();
+    }
 }
 
 contract MockPerspective {
-    function isVerified(address) external pure returns(bool) {
+    function isVerified(address) external pure returns (bool) {
         return true;
     }
 }
-

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -20,6 +20,7 @@ contract RescuePOC is Test {
     address constant OTHER_EARN_VAULT = 0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB; // https://app.euler.finance/earn/0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB?network=ethereum
     address constant FLASH_LOAN_SOURCE_MORPHO = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
     address constant FLASH_LOAN_SOURCE_EULER = 0x797DD80692c3b2dAdabCe8e30C07fDE5307D48a9; // Euler Prime - also a strategy in earn
+    address constant FLASH_LOAN_SOURCE_AAVE = 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2;
     uint256 constant BLOCK_NUMBER = 23753054;
 
 	IEulerEarn vault;
@@ -141,10 +142,34 @@ contract RescuePOC is Test {
         // only rescue account
         vm.prank(user);
         vm.expectRevert("unauthorized");
-        rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_MORPHO);
+        rescueStrategy.rescueMorpho(amount, loops, FLASH_LOAN_SOURCE_MORPHO);
 
         vm.startPrank(rescueAccount);
         rescueStrategy.rescueMorpho(amount, loops, FLASH_LOAN_SOURCE_MORPHO);
+
+        assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);
+
+        console.log("Rescued", IERC20(vault.asset()).balanceOf(rescueAccount), IEulerEarn(vault.asset()).symbol());
+        console.log("Received shares", IERC4626(vault).balanceOf(rescueAccount));
+    }
+
+    function testRescue_rescueAave() public {
+        _installRescueStrategy();
+
+        uint256 amount = 5_000_000e6;
+        uint256 loops = 1;
+
+        // only rescue account
+        vm.prank(user);
+        vm.expectRevert("unauthorized");
+        rescueStrategy.rescueAave(amount, loops, FLASH_LOAN_SOURCE_AAVE);
+
+        vm.startPrank(rescueAccount);
+        vm.expectRevert("insufficient funds to repay flashloan");
+        rescueStrategy.rescueAave(amount, loops, FLASH_LOAN_SOURCE_AAVE);
+
+        deal(vault.asset(), address(rescueStrategy), amount * 5 / 10000);
+        rescueStrategy.rescueAave(amount, loops, FLASH_LOAN_SOURCE_AAVE);
 
         assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);
 

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -20,8 +20,6 @@ contract RescuePOC is Test {
     address constant OTHER_EARN_VAULT = 0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB; // https://app.euler.finance/earn/0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB?network=ethereum
     address constant FLASH_LOAN_SOURCE_MORPHO = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
     address constant FLASH_LOAN_SOURCE_EULER = 0x797DD80692c3b2dAdabCe8e30C07fDE5307D48a9; // Euler Prime - also a strategy in earn
-    address constant RESCUE_EOA = address(10000);
-    address constant FUNDS_RECEIVER = address(20000);
     uint256 constant BLOCK_NUMBER = 23753054;
 
 	IEulerEarn vault;
@@ -30,6 +28,7 @@ contract RescuePOC is Test {
 
 	uint256 fork;
 
+    address rescueAccount = makeAddr("rescueAccount");
 	address user = makeAddr("user");
     RescueStrategy rescueStrategy;
 
@@ -70,29 +69,39 @@ contract RescuePOC is Test {
 
         uint256 amount = 100_000e6;
 
-        vm.startPrank(RESCUE_EOA, RESCUE_EOA);
+        // only rescue account
+        vm.prank(user);
+        vm.expectRevert("unauthorized");
         rescueStrategy.rescueEulerBatch(amount, FLASH_LOAN_SOURCE_EULER);
 
-        assertGt(IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), 0);
+        vm.startPrank(rescueAccount);
+        rescueStrategy.rescueEulerBatch(amount, FLASH_LOAN_SOURCE_EULER);
+
+        assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);
         assertEq(IEVC(vault.EVC()).getControllers(address(rescueStrategy)).length, 0);
 
-        console.log("Rescued", IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), IEulerEarn(vault.asset()).symbol());
-        console.log("Received shares", IERC4626(vault).balanceOf(FUNDS_RECEIVER));
+        console.log("Rescued", IERC20(vault.asset()).balanceOf(rescueAccount), IEulerEarn(vault.asset()).symbol());
+        console.log("Received shares", IERC4626(vault).balanceOf(rescueAccount));
     }
 
-    function testRescue_rescueOneGoMorpho() public {
+    function testRescue_rescueMorpho() public {
         _installRescueStrategy();
 
         // create shares equal total supply + extra
         uint256 amount = vault.previewMint(vault.totalSupply()) * 10001 / 10000;
 
-        vm.startPrank(RESCUE_EOA, RESCUE_EOA);
+        // only rescue account
+        vm.prank(user);
+        vm.expectRevert("unauthorized");
+        rescueStrategy.rescueEulerBatch(amount, FLASH_LOAN_SOURCE_MORPHO);
+
+        vm.startPrank(rescueAccount);
         rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
 
-        assertGt(IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), 0);
+        assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);
 
-        console.log("Rescued", IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), IEulerEarn(vault.asset()).symbol());
-        console.log("Received shares", IERC4626(vault).balanceOf(FUNDS_RECEIVER));
+        console.log("Rescued", IERC20(vault.asset()).balanceOf(rescueAccount), IEulerEarn(vault.asset()).symbol());
+        console.log("Received shares", IERC4626(vault).balanceOf(rescueAccount));
     }
 
     function testRescue_rescueMultipleMorpho() public {
@@ -100,34 +109,33 @@ contract RescuePOC is Test {
 
         uint256 amount = 1000000000000;
 
-        vm.startPrank(RESCUE_EOA, RESCUE_EOA);
+        vm.startPrank(rescueAccount);
         rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
         rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
         rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
 
-        assertGt(IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), 0);
+        assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);
 
-        console.log("Rescued", IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), IEulerEarn(vault.asset()).symbol());
-        console.log("Received shares", IERC4626(vault).balanceOf(FUNDS_RECEIVER));
+        console.log("Rescued", IERC20(vault.asset()).balanceOf(rescueAccount), IEulerEarn(vault.asset()).symbol());
+        console.log("Received shares", IERC4626(vault).balanceOf(rescueAccount));
     }
 
-    function testRescue_rescueEOACanWithdrawAnyTime() public {
+    function testRescue_rescueAccountCantWithdrawOutsideRescue() public {
         _installRescueStrategy();
 
         vm.prank(user);
 		vm.expectRevert("vault operations are paused");
         vault.withdraw(1e6, user, user);
 
-        deal(address(vault), RESCUE_EOA, 1e6);
+        deal(address(vault), rescueAccount, 1e6);
 
-        vm.prank(RESCUE_EOA, RESCUE_EOA);
-        vault.withdraw(1e6, RESCUE_EOA, RESCUE_EOA);
-
-        assertEq(IERC20(vault.asset()).balanceOf(RESCUE_EOA), 1e6);
+        vm.prank(rescueAccount);
+        vm.expectRevert("vault operations are paused");
+        vault.withdraw(1e6, rescueAccount, rescueAccount);
     }
 
     function testRescue_cantBeReused() public {
-        rescueStrategy = new RescueStrategy(RESCUE_EOA, address(vault), FUNDS_RECEIVER);
+        rescueStrategy = new RescueStrategy(rescueAccount, address(vault));
 
 		// install perspective in earn factory which will allow custom strategies
 		_installPerspective();
@@ -183,12 +191,34 @@ contract RescuePOC is Test {
         assertEq(vault.balanceOf(user), 0);
     }
 
+    function testRescue_onlyRescueAccountCallFunc() external {
+        _installRescueStrategy();
+
+        vm.prank(user);
+        vm.expectRevert("unauthorized");
+        rescueStrategy.call(address(0), "");
+
+        vm.prank(rescueAccount);
+        rescueStrategy.call(address(0), "");
+    }
+
+    function testRescue_flashloanCallbacks() external {
+        _installRescueStrategy();
+
+        vm.expectRevert("vault operations are paused");
+        rescueStrategy.onBatchLoan(1);
+        vm.expectRevert("vault operations are paused");
+        rescueStrategy.onFlashLoan("");
+        vm.expectRevert("vault operations are paused");
+        rescueStrategy.onMorphoFlashLoan(1, "");
+    }
+
 	function _installRescueStrategy() internal {
 		// install perspective in earn factory which will allow custom strategies (use mock here)
 		_installPerspective();
 
 		// deploy strategy, set a cap for it and put in in the supply and withdraw queues
-		rescueStrategy = new RescueStrategy(RESCUE_EOA, address(vault), FUNDS_RECEIVER);
+		rescueStrategy = new RescueStrategy(rescueAccount, address(vault));
 
 		vm.startPrank(vault.curator());
 

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -134,7 +134,7 @@ contract RescuePOC is Test {
         console.log("Rescued", rescueOneLoop, IEulerEarn(vault.asset()).symbol());
         console.log("Received shares", IERC4626(vault).balanceOf(rescueAccount));
 
-        vm.revertTo(snapshot);
+        vm.revertToState(snapshot);
         loops = 2;
 
         rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_EULER);
@@ -329,6 +329,17 @@ contract RescuePOC is Test {
         vm.startPrank(address(vault));
         vm.expectRevert("vault operations are paused - maxDeposit");
         rescueStrategy.maxDeposit(user);
+    }
+
+    function testRescue_deposit() external {
+        _installRescueStrategy();
+        vm.prank(user);
+        vm.expectRevert("not supported");
+        rescueStrategy.deposit(1, user);
+
+        vm.prank(address(vault));
+        vm.expectRevert("only during rescue");
+        rescueStrategy.deposit(1, address(vault));
     }
 
     function testRescue_balanceOfView() external {

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -99,13 +99,13 @@ contract RescuePOC is Test {
         _installRescueStrategy();
 
         vm.startPrank(user);
-        vm.expectRevert("vault operations are paused - maxDeposit");
+        vm.expectRevert("vault operations are paused");
         vault.deposit(10, user);
-        vm.expectRevert("vault operations are paused - maxDeposit");
+        vm.expectRevert("vault operations are paused");
         vault.mint(10, user);
-        vm.expectRevert("vault operations are paused - maxWithdraw");
+        vm.expectRevert("vault operations are paused");
         vault.withdraw(0, user, user);
-        vm.expectRevert("vault operations are paused - maxWithdraw");
+        vm.expectRevert("vault operations are paused");
         vault.redeem(0, user, user);
 
         assertEq(vault.maxWithdrawFromStrategy(IERC4626(address(rescueStrategy))), 0);
@@ -213,13 +213,13 @@ contract RescuePOC is Test {
         _installRescueStrategy();
 
         vm.prank(user);
-        vm.expectRevert("vault operations are paused - maxWithdraw");
+        vm.expectRevert("vault operations are paused");
         vault.withdraw(1e6, user, user);
 
         deal(address(vault), rescueAccount, 1e6);
 
         vm.prank(rescueAccount);
-        vm.expectRevert("vault operations are paused - maxWithdraw");
+        vm.expectRevert("vault operations are paused");
         vault.withdraw(1e6, rescueAccount, rescueAccount);
     }
 
@@ -242,7 +242,7 @@ contract RescuePOC is Test {
         _installRescueStrategy();
 
         vm.startPrank(user);
-        vm.expectRevert("vault operations are paused - maxDeposit");
+        vm.expectRevert("vault operations are paused");
         vault.deposit(10, user);
 
         vm.startPrank(vault.curator());
@@ -292,13 +292,13 @@ contract RescuePOC is Test {
     function testRescue_flashloanCallbacks() external {
         _installRescueStrategy();
 
-        vm.expectRevert("vault operations are paused");
+        vm.expectRevert("unauthorized");
         rescueStrategy.onBatchLoan(1, 1);
-        vm.expectRevert("vault operations are paused");
+        vm.expectRevert("unauthorized");
         rescueStrategy.onFlashLoan("");
-        vm.expectRevert("vault operations are paused");
+        vm.expectRevert("unauthorized");
         rescueStrategy.onMorphoFlashLoan(1, "");
-        vm.expectRevert("vault operations are paused");
+        vm.expectRevert("unauthorized");
         rescueStrategy.executeOperation(address(1), 1, 1, address(1), "");
     }
 
@@ -330,8 +330,7 @@ contract RescuePOC is Test {
         assertEq(rescueStrategy.maxDeposit(user), 0);
 
         vm.startPrank(address(vault));
-        vm.expectRevert("vault operations are paused - maxDeposit");
-        rescueStrategy.maxDeposit(user);
+        assertEq(rescueStrategy.maxDeposit(user), 0);
     }
 
     function testRescue_deposit() external {

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -50,6 +50,43 @@ contract RescuePOC is Test {
         );
 	}
 
+    function testRescue_assertRescueMode() public {
+		_installPerspective();
+
+		rescueStrategy = new RescueStrategy(rescueAccount, address(vault));
+        IERC4626 id = IERC4626(address(rescueStrategy));
+
+        vm.prank(rescueAccount);
+        vm.expectRevert("rescue: supplyQueue len != 1");
+        rescueStrategy.rescueEulerBatch(1, FLASH_LOAN_SOURCE_EULER);
+
+        IERC4626[] memory supplyQueue = new IERC4626[](1);
+		supplyQueue[0] = vault.supplyQueue(0);
+
+		vm.prank(vault.curator());
+        vault.setSupplyQueue(supplyQueue);
+
+        vm.prank(rescueAccount);
+        vm.expectRevert("rescue: supplyQueue[0] != rescue");
+        rescueStrategy.rescueEulerBatch(1, FLASH_LOAN_SOURCE_EULER);
+		
+        vm.prank(vault.curator());
+		vault.submitCap(id, type(uint184).max);
+
+		skip(vault.timelock());
+
+        vm.prank(vault.curator());
+		vault.acceptCap(id);
+		supplyQueue[0] = id;
+
+        vm.prank(vault.curator());
+		vault.setSupplyQueue(supplyQueue);
+
+        vm.prank(rescueAccount);
+        vm.expectRevert("rescue: withdrawQueue[0] != rescue");
+        rescueStrategy.rescueEulerBatch(1, FLASH_LOAN_SOURCE_EULER);
+    }
+
 	function testRescue_pauseForUsers() public {
 		_installRescueStrategy();
 

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -8,6 +8,7 @@ import {IEulerEarnFactory} from "../src/interfaces/IEulerEarnFactory.sol";
 import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
 import {IAllowanceTransfer} from "../src/interfaces/IAllowanceTransfer.sol";
 import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
+import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {RescueStrategy} from "../src/RescueStrategy.sol";
 import "forge-std/Test.sol";
 
@@ -17,14 +18,15 @@ contract RescuePOC is Test {
     address constant EARN_VAULT = 0x3B4802FDb0E5d74aA37d58FD77d63e93d4f9A4AF; // https://app.euler.finance/earn/0x3B4802FDb0E5d74aA37d58FD77d63e93d4f9A4AF?network=ethereum 
 
     address constant OTHER_EARN_VAULT = 0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB; // https://app.euler.finance/earn/0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB?network=ethereum
-    address constant FLASH_LOAN_SOURCE = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb; // morpho
+    address constant FLASH_LOAN_SOURCE_MORPHO = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
+    address constant FLASH_LOAN_SOURCE_EULER = 0x797DD80692c3b2dAdabCe8e30C07fDE5307D48a9; // Euler Prime - also a strategy in earn
     address constant RESCUE_EOA = address(10000);
     address constant FUNDS_RECEIVER = address(20000);
+    uint256 constant BLOCK_NUMBER = 23753054;
 
 	IEulerEarn vault;
 
 	string FORK_RPC_URL = vm.envOr("FORK_RPC_URL_MAINNET", string(""));
-	uint256 BLOCK_NUMBER = vm.envOr("FORK_BLOCK_NUMBER", uint256(0));
 
 	uint256 fork;
 
@@ -33,10 +35,6 @@ contract RescuePOC is Test {
 
  	function setUp() public {
 		require(bytes(FORK_RPC_URL).length != 0, "No FORK_RPC_URL env found");
-		require(RESCUE_EOA != address(0), "No RESCUE_EOA env found");
-		require(EARN_VAULT != address(0), "No EARN_VAULT env found");
-		require(FLASH_LOAN_SOURCE != address(0), "No FLASH_LOAN_SOURCE env found");
-		require(FUNDS_RECEIVER != address(0), "No FUNDS_RECEIVER env found");
 
 		fork = vm.createSelectFork(FORK_RPC_URL);
 		if (BLOCK_NUMBER > 0) {
@@ -67,14 +65,29 @@ contract RescuePOC is Test {
 		vault.redeem(0, user, user);
 	}
 
-    function testRescue_rescueOneGo() public {
+    function testRescue_rescueEulerBatch() public {
+        _installRescueStrategy();
+
+        uint256 amount = 100_000e6;
+
+        vm.startPrank(RESCUE_EOA, RESCUE_EOA);
+        rescueStrategy.rescueEulerBatch(amount, FLASH_LOAN_SOURCE_EULER);
+
+        assertGt(IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), 0);
+        assertEq(IEVC(vault.EVC()).getControllers(address(rescueStrategy)).length, 0);
+
+        console.log("Rescued", IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), IEulerEarn(vault.asset()).symbol());
+        console.log("Received shares", IERC4626(vault).balanceOf(FUNDS_RECEIVER));
+    }
+
+    function testRescue_rescueOneGoMorpho() public {
         _installRescueStrategy();
 
         // create shares equal total supply + extra
         uint256 amount = vault.previewMint(vault.totalSupply()) * 10001 / 10000;
 
         vm.startPrank(RESCUE_EOA, RESCUE_EOA);
-        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE);
+        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
 
         assertGt(IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), 0);
 
@@ -82,15 +95,15 @@ contract RescuePOC is Test {
         console.log("Received shares", IERC4626(vault).balanceOf(FUNDS_RECEIVER));
     }
 
-    function testRescue_rescueMultiple() public {
+    function testRescue_rescueMultipleMorpho() public {
         _installRescueStrategy();
 
         uint256 amount = 1000000000000;
 
         vm.startPrank(RESCUE_EOA, RESCUE_EOA);
-        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE);
-        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE);
-        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE);
+        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
+        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
+        rescueStrategy.rescueMorpho(amount, FLASH_LOAN_SOURCE_MORPHO);
 
         assertGt(IERC20(vault.asset()).balanceOf(FUNDS_RECEIVER), 0);
 

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -19,7 +19,8 @@ contract RescuePOC is Test {
 
     address constant OTHER_EARN_VAULT = 0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB; // https://app.euler.finance/earn/0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB?network=ethereum
     address constant FLASH_LOAN_SOURCE_MORPHO = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
-    address constant FLASH_LOAN_SOURCE_EULER = 0x797DD80692c3b2dAdabCe8e30C07fDE5307D48a9; // Euler Prime - also a strategy in earn
+    address constant FLASH_LOAN_SOURCE_EULER = 0x9bD52F2805c6aF014132874124686e7b248c2Cbb;
+    address constant FLASH_LOAN_SOURCE_EULER_BATCH = 0x797DD80692c3b2dAdabCe8e30C07fDE5307D48a9; // Euler Prime - also a strategy in earn
     address constant FLASH_LOAN_SOURCE_AAVE = 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2;
     address constant EARN_LENS = 0xA09144BeAe23D8e7836Aeb0Fe17DD2647241A8bE;
     address constant EVAULT_LENS = 0xc3c45633E45041BF3BE841f89d2cb51E2F657403;
@@ -67,7 +68,7 @@ contract RescuePOC is Test {
 
         vm.prank(rescueAccount);
         vm.expectRevert("rescue: supplyQueue len != 1");
-        rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER);
+        rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER_BATCH);
 
         IERC4626[] memory supplyQueue = new IERC4626[](1);
         supplyQueue[0] = vault.supplyQueue(0);
@@ -77,7 +78,7 @@ contract RescuePOC is Test {
 
         vm.prank(rescueAccount);
         vm.expectRevert("rescue: supplyQueue[0] != rescue");
-        rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER);
+        rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER_BATCH);
 
         vm.prank(vault.curator());
         vault.submitCap(id, type(uint184).max);
@@ -93,7 +94,7 @@ contract RescuePOC is Test {
 
         vm.prank(rescueAccount);
         vm.expectRevert("rescue: withdrawQueue[0] != rescue");
-        rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER);
+        rescueStrategy.rescueEulerBatch(1, 1, FLASH_LOAN_SOURCE_EULER_BATCH);
     }
 
     function testRescue_pauseForUsers() public {
@@ -129,12 +130,12 @@ contract RescuePOC is Test {
         // only rescue account
         vm.prank(user);
         vm.expectRevert("unauthorized");
-        rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_EULER);
+        rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_EULER_BATCH);
 
         vm.startPrank(rescueAccount);
         vm.expectEmit(true, true, false, false);
         emit RescueStrategy.Rescued(address(vault), 0);
-        rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_EULER);
+        rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_EULER_BATCH);
 
         assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);
         assertEq(IEVC(vault.EVC()).getControllers(address(rescueStrategy)).length, 0);
@@ -146,7 +147,7 @@ contract RescuePOC is Test {
         vm.revertToState(snapshot);
         loops = 2;
 
-        rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_EULER);
+        rescueStrategy.rescueEulerBatch(amount, loops, FLASH_LOAN_SOURCE_EULER_BATCH);
         assertEq(IERC20(vault.asset()).balanceOf(rescueAccount), rescueOneLoop * 2);
 
         // caps are unchanged on other strategies
@@ -157,6 +158,36 @@ contract RescuePOC is Test {
                 assertEq(strategyCaps[strategy], vault.config(vault.withdrawQueue(i)).cap);
             }
         }
+    }
+
+    function testRescue_rescueEuler() public {
+        _installRescueStrategy();
+
+        uint256 amount = 100_000e6;
+        uint256 loops = 1;
+        uint256 snapshot = vm.snapshotState();
+        // only rescue account
+        vm.prank(user);
+        vm.expectRevert("unauthorized");
+        rescueStrategy.rescueEuler(amount, loops, FLASH_LOAN_SOURCE_EULER);
+
+        vm.startPrank(rescueAccount);
+        vm.expectEmit(true, true, false, false);
+        emit RescueStrategy.Rescued(address(vault), 0);
+        rescueStrategy.rescueEuler(amount, loops, FLASH_LOAN_SOURCE_EULER);
+
+        assertGt(IERC20(vault.asset()).balanceOf(rescueAccount), 0);
+        assertEq(IEVC(vault.EVC()).getControllers(address(rescueStrategy)).length, 0);
+        uint256 rescueOneLoop = IERC20(vault.asset()).balanceOf(rescueAccount);
+
+        console.log("Rescued", rescueOneLoop, IEulerEarn(vault.asset()).symbol());
+        console.log("Received shares", IERC4626(vault).balanceOf(rescueAccount));
+
+        vm.revertTo(snapshot);
+        loops = 2;
+
+        rescueStrategy.rescueEuler(amount, loops, FLASH_LOAN_SOURCE_EULER);
+        assertEq(IERC20(vault.asset()).balanceOf(rescueAccount), rescueOneLoop * 2);
     }
 
     function testRescue_rescueMorpho() public {

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -10,6 +10,7 @@ import {IAllowanceTransfer} from "../src/interfaces/IAllowanceTransfer.sol";
 import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {RescueStrategy} from "../src/RescueStrategy.sol";
+import {EulerEarnVaultLens as EarnIndexerLens} from "../lib/euler-data-lenses/src/EulerEarnLens.sol";
 import "forge-std/Test.sol";
 
 contract RescuePOC is Test {
@@ -20,9 +21,13 @@ contract RescuePOC is Test {
     address constant FLASH_LOAN_SOURCE_MORPHO = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
     address constant FLASH_LOAN_SOURCE_EULER = 0x797DD80692c3b2dAdabCe8e30C07fDE5307D48a9; // Euler Prime - also a strategy in earn
     address constant FLASH_LOAN_SOURCE_AAVE = 0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2;
+    address constant EARN_LENS = 0xA09144BeAe23D8e7836Aeb0Fe17DD2647241A8bE;
     uint256 constant BLOCK_NUMBER = 23753054;
 
     IEulerEarn vault;
+    IEulerEarn otherVault;
+
+    address indexerLens;
 
     string FORK_RPC_URL = vm.envOr("FORK_RPC_URL_MAINNET", string(""));
 
@@ -41,6 +46,7 @@ contract RescuePOC is Test {
         }
 
         vault = IEulerEarn(EARN_VAULT);
+        otherVault = IEulerEarn(OTHER_EARN_VAULT); // hyperithm euler usdc mainnet
 
         deal(vault.asset(), user, 100e18);
         vm.startPrank(user);
@@ -48,6 +54,8 @@ contract RescuePOC is Test {
         IAllowanceTransfer(vault.permit2Address()).approve(
             vault.asset(), address(vault), type(uint160).max, type(uint48).max
         );
+
+        indexerLens = address(new EarnIndexerLens());
     }
 
     function testRescue_assertRescueMode() public {
@@ -91,13 +99,13 @@ contract RescuePOC is Test {
         _installRescueStrategy();
 
         vm.startPrank(user);
-        vm.expectRevert("vault operations are paused");
+        vm.expectRevert("vault operations are paused - maxDeposit");
         vault.deposit(10, user);
-        vm.expectRevert("vault operations are paused");
+        vm.expectRevert("vault operations are paused - maxDeposit");
         vault.mint(10, user);
-        vm.expectRevert("vault operations are paused");
+        vm.expectRevert("vault operations are paused - maxWithdraw");
         vault.withdraw(0, user, user);
-        vm.expectRevert("vault operations are paused");
+        vm.expectRevert("vault operations are paused - maxWithdraw");
         vault.redeem(0, user, user);
 
         assertEq(vault.maxWithdrawFromStrategy(IERC4626(address(rescueStrategy))), 0);
@@ -205,13 +213,13 @@ contract RescuePOC is Test {
         _installRescueStrategy();
 
         vm.prank(user);
-        vm.expectRevert("vault operations are paused");
+        vm.expectRevert("vault operations are paused - maxWithdraw");
         vault.withdraw(1e6, user, user);
 
         deal(address(vault), rescueAccount, 1e6);
 
         vm.prank(rescueAccount);
-        vm.expectRevert("vault operations are paused");
+        vm.expectRevert("vault operations are paused - maxWithdraw");
         vault.withdraw(1e6, rescueAccount, rescueAccount);
     }
 
@@ -220,8 +228,6 @@ contract RescuePOC is Test {
 
         // install perspective in earn factory which will allow custom strategies
         _installPerspective();
-
-        IEulerEarn otherVault = IEulerEarn(OTHER_EARN_VAULT); // hyperithm euler usdc mainnet
 
         vm.startPrank(otherVault.curator());
 
@@ -236,7 +242,7 @@ contract RescuePOC is Test {
         _installRescueStrategy();
 
         vm.startPrank(user);
-        vm.expectRevert("vault operations are paused");
+        vm.expectRevert("vault operations are paused - maxDeposit");
         vault.deposit(10, user);
 
         vm.startPrank(vault.curator());
@@ -294,6 +300,49 @@ contract RescuePOC is Test {
         rescueStrategy.onMorphoFlashLoan(1, "");
         vm.expectRevert("vault operations are paused");
         rescueStrategy.executeOperation(address(1), 1, 1, address(1), "");
+    }
+
+    function testRescue_callLenses() external {
+        _installRescueStrategy();
+
+        (bool success, bytes memory data) = EARN_LENS.call(abi.encodeWithSignature("getVaultInfoFull(address)", address(vault)));
+        assertTrue(success && data.length > 0);
+
+        (success, data) = indexerLens.call(abi.encodeWithSignature("getVaultInfoFull(address)", address(vault)));
+        assertTrue(success && data.length > 0);
+    }
+
+    function testRescue_maxWithdrawView() external {
+        _installRescueStrategy();
+        vm.prank(user);
+        assertEq(rescueStrategy.maxWithdraw(user), 0);
+
+        vm.startPrank(address(vault));
+        assertEq(rescueStrategy.maxWithdraw(user), 0);
+    }
+
+    function testRescue_maxDepositView() external {
+        _installRescueStrategy();
+        vm.prank(user);
+        assertEq(rescueStrategy.maxDeposit(user), 0);
+
+        vm.startPrank(address(vault));
+        vm.expectRevert("vault operations are paused - maxDeposit");
+        rescueStrategy.maxDeposit(user);
+    }
+
+    function testRescue_balanceOfView() external {
+        _installRescueStrategy();
+        vm.prank(user);
+        assertEq(rescueStrategy.balanceOf(user), 0);
+
+        vm.startPrank(address(vault));
+        assertEq(rescueStrategy.balanceOf(user), 0);
+
+        vm.startPrank(address(otherVault));
+        vm.expectRevert("wrong vault");
+        rescueStrategy.balanceOf(user);
+
     }
 
     function _installRescueStrategy() internal {

--- a/test/RescueStrategyTest.sol
+++ b/test/RescueStrategyTest.sol
@@ -10,7 +10,7 @@ import {IAllowanceTransfer} from "../src/interfaces/IAllowanceTransfer.sol";
 import {EnumerableSet} from "openzeppelin-contracts/utils/structs/EnumerableSet.sol";
 import {IEVC} from "ethereum-vault-connector/interfaces/IEthereumVaultConnector.sol";
 import {RescueStrategy} from "../src/RescueStrategy.sol";
-import {EulerEarnVaultLens as EarnIndexerLens} from "../lib/euler-data-lenses/src/EulerEarnLens.sol";
+import {EulerEarnVaultLens as EarnIndexerLens, EulerEarnVaultInfoFull} from "../lib/euler-data-lenses/src/EulerEarnLens.sol";
 import "forge-std/Test.sol";
 
 contract RescuePOC is Test {
@@ -27,7 +27,7 @@ contract RescuePOC is Test {
     IEulerEarn vault;
     IEulerEarn otherVault;
 
-    address indexerLens;
+    EarnIndexerLens indexerLens;
 
     string FORK_RPC_URL = vm.envOr("FORK_RPC_URL_MAINNET", string(""));
 
@@ -55,7 +55,7 @@ contract RescuePOC is Test {
             vault.asset(), address(vault), type(uint160).max, type(uint48).max
         );
 
-        indexerLens = address(new EarnIndexerLens());
+        indexerLens = new EarnIndexerLens();
     }
 
     function testRescue_assertRescueMode() public {
@@ -304,12 +304,15 @@ contract RescuePOC is Test {
 
     function testRescue_callLenses() external {
         _installRescueStrategy();
+        // lens calls don't revert
 
+        // onchain lens
         (bool success, bytes memory data) = EARN_LENS.call(abi.encodeWithSignature("getVaultInfoFull(address)", address(vault)));
         assertTrue(success && data.length > 0);
 
-        (success, data) = indexerLens.call(abi.encodeWithSignature("getVaultInfoFull(address)", address(vault)));
-        assertTrue(success && data.length > 0);
+        // lens used in the indexer by setting the `code` in eth_call
+        EulerEarnVaultInfoFull memory lensData = indexerLens.getVaultInfoFull(address(vault));
+        assertEq(lensData.vault, address(vault));
     }
 
     function testRescue_maxWithdrawView() external {


### PR DESCRIPTION
The PR introduces a RescueStrategy. It allows curators to withdraw funds from strategies to distribute fairly to users when vault faces large debt socializations.

Rescue procedure:
    - Euler installs a perspective in the earn factory which allows adding custom strategies
    - RescueStrategy contracts are deployed for each earn vault to rescue. 
      Immutable params:
        o Rescue account: is allowed to call the rescue functions and receives rescued assets and shares
        o Earn vault: the strategy can only work with the specified vault. If another vault tries to enable it, it will revert on `acceptCap`
    - Euler registers the strategies in the perspective
    - Curator installs the strategy with unlimited cap (submit/acceptCap)
    - Curator sets the new strategy as the only one in supply queue and moves it to the front of withdraw queue
        o at this stage the regular users can't deposit or withdraw from earn
    - Rescue account calls one of the `rescueX` functions (for Euler, Morpho or Aave flash loan sources), specifying the asset amount to flashloan
        o flash loan is used to create earn vault shares, it just passes through earn vault back to the rescue strategy where it is repaid
        o the shares are used to withdraw as much as possible from the underlying strategies to the rescue account