### PR TITLE
fix: remove unfulfilled dual-license preamble from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,3 @@
-This software is available under your choice of the GNU General Public
-License, version 2 or later, or the Business Source License, as set
-forth below.
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 


### PR DESCRIPTION
The LICENSE preamble offered a choice between GPL-2.0-or-later and the Business Source License, but the file only ever contained the GPL text — no BUSL terms or parameters were included, so the offered choice could not be exercised. This removes the inaccurate preamble, leaving the plain GPL-2.0 text, which matches the source SPDX headers (`GPL-2.0-or-later`) and is byte-identical to the LICENSE of the upstream fork base (morpho-org/metamorpho-v1.1).